### PR TITLE
Removed the unnecessary settings in terasoluna-gfw-security-web/pom.xml #3

### DIFF
--- a/terasoluna-gfw-security-web/pom.xml
+++ b/terasoluna-gfw-security-web/pom.xml
@@ -33,12 +33,6 @@
             <plugin>
                 <groupId>com.google.code.maven-license-plugin</groupId>
                 <artifactId>maven-license-plugin</artifactId>
-                <configuration>
-                  <excludes>
-                      <exclude>src/main/java/org/springframework/**</exclude>
-                      <exclude>src/test/java/org/springframework/**</exclude>
-                  </excludes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -143,12 +137,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <version>1.4</version>
-            <scope>test</scope>
         </dependency>
         <!-- == End Unit Test == -->
 


### PR DESCRIPTION
I've removed the unnecessary old settings.
- excludes settings(`org/springframework/**`) of maven-license-plugin
- testing library(`org.easytesting:fest-assert:1.4`)

Please review #3 , and merge to master branch.
