### PR TITLE
Removed the exclusions setting from tiles-core. #178

### DIFF
--- a/terasoluna-gfw-recommended-web-dependencies/pom.xml
+++ b/terasoluna-gfw-recommended-web-dependencies/pom.xml
@@ -18,16 +18,6 @@
         <dependency>
             <groupId>org.apache.tiles</groupId>
             <artifactId>tiles-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>commons-logging</artifactId>
-                    <groupId>commons-logging</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.tiles</groupId>


### PR DESCRIPTION
Reason that remove the exclusions is follows;
- `commons-logging` has been excluded in `tiles-core`.
- `jcl-over-slf4j`' version has been managed by Spring IO Platform.

Please review #178.
