### PR TITLE
[5.0.x] #290: Support Oracle JDK8 as new build environment on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6


### PR DESCRIPTION
(cherry picked from commit ba9292ddd9ef70d28b46b65f7fbce464d3e00d82)

Please review #290 .