### PR TITLE
Support terasoluna-gfw-validator on Travis-CI #372

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,8 @@ cache:
 
 install: true
 
-script: ./mvn-build-all.sh
+script:
+  - jdk_switcher use oraclejdk8
+  - export JAVA8_PLUS_HOME=$JAVA_HOME
+  - jdk_switcher use $TRAVIS_JDK_VERSION
+  - ./mvn-build-all.sh

--- a/mvn-build-all.sh
+++ b/mvn-build-all.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
 ARTIFACT_ID_PREFIX="terasoluna-gfw-"
-TARGETS="parent common jodatime web security-core security-web jpa mybatis3 mybatis2 recommended-dependencies recommended-web-dependencies"
+TARGETS_JAVA7_PLUS="parent common jodatime web security-core security-web jpa mybatis3 mybatis2 recommended-dependencies recommended-web-dependencies"
+TARGETS_JAVA8_PLUS="validator"
 DEFAULT_GOALS="clean install"
+ORIGINAL_JAVA_HOME=${JAVA_HOME}
+
+# e.g.)
+# 1.7.0_xx : 7
+# 1.8.0_xx : 8
+declare -i CURRENT_JDK_VERSION=`javac -version 2>&1 | sed 's/javac \([0-9]\).\([0-9]\).*/\2/;'`
 
 commandArgs=${DEFAULT_GOALS}
 if test $# -ne 0 ; then
@@ -13,9 +20,36 @@ echo "[INFO] Start a build."
 
 echo "[DEBUG] Command arguments : \"${commandArgs}\""
 
-for target in ${TARGETS}; do
+# Build modules for JDK requirement is 7+
+for target in ${TARGETS_JAVA7_PLUS}; do
     artifactId=${ARTIFACT_ID_PREFIX}${target}
     if test -f ${artifactId}/pom.xml ; then
+        # Build a target module
+        mvn -U -f ${artifactId}/pom.xml ${commandArgs}
+        buildResult=$?
+        if test ${buildResult} -ne 0 ; then
+            echo "[ERROR] Failed a build."
+            exit ${buildResult}
+        fi
+    fi
+done
+
+# Build modules for JDK requirement is 8+
+for target in ${TARGETS_JAVA8_PLUS}; do
+    if test -f ${artifactId}/pom.xml ; then
+        artifactId=${ARTIFACT_ID_PREFIX}${target}
+        # If present the 'JAVA8_PLUS_HOME' environment variable, install latest module using JDK 8+.
+        if test ${CURRENT_JDK_VERSION} -lt 8 && test -n ${JAVA8_PLUS_HOME} ; then
+            export JAVA_HOME=${JAVA8_PLUS_HOME}
+            mvn -U -f ${artifactId}/pom.xml clean install -Dmaven.test.skip=true -Dmaven.javadoc.skip=true -Dsource.skip=true
+            buildResult=$?
+            if test ${buildResult} -ne 0 ; then
+                echo "[ERROR] Failed a build on pre install."
+                exit ${buildResult}
+            fi
+        fi
+        # Build a target module
+        export JAVA_HOME=${ORIGINAL_JAVA_HOME}
         mvn -U -f ${artifactId}/pom.xml ${commandArgs}
         buildResult=$?
         if test ${buildResult} -ne 0 ; then
@@ -26,3 +60,14 @@ for target in ${TARGETS}; do
 done
 
 echo "[INFO] Finish a build."
+
+# Display warning logs(less than Java 8)
+if test ${CURRENT_JDK_VERSION} -lt 8 ; then
+    echo "[WARNING] In below modules, skip a compile(and install, deploy, etc...) because it need the JDK 8+ for full build.";
+    for target in ${TARGETS_JAVA8_PLUS}; do
+        echo "${ARTIFACT_ID_PREFIX}${target}"
+    done
+    if test -z ${JAVA8_PLUS_HOME} ; then
+        echo "[WARNING] Performed tests using artifact which installed into maven repository. If you want to perform tests using latest module, please define the 'JAVA8_PLUS_HOME' environment variable.";
+    fi
+fi

--- a/terasoluna-gfw-validator/pom.xml
+++ b/terasoluna-gfw-validator/pom.xml
@@ -96,4 +96,44 @@
         </dependency>
         <!-- == End Unit Test == -->
     </dependencies>
+    <profiles>
+        <!-- Profile for CI on Java 7 -->
+        <profile>
+            <id>jdk1.7</id>
+            <activation>
+                <jdk>1.7</jdk>
+            </activation>
+            <properties>
+                <!-- Skip settings -->
+                <maven.install.skip>true</maven.install.skip>
+                <maven.deploy.skip>true</maven.deploy.skip>
+                <maven.main.skip>true</maven.main.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <jar.skipIfEmpty>true</jar.skipIfEmpty>
+                <source.skip>true</source.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <!-- Ignore test classes of JSR-310(depends on Java 8+) -->
+                            <testExcludes>
+                                <exclude>**/*JSR310*</exclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <!-- Get test target module from maven repository -->
+                <dependency>
+                    <groupId>org.terasoluna.gfw</groupId>
+                    <artifactId>terasoluna-gfw-validator</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
I've added `terasoluna-gfw-validator` on Travis-CI.
I will be continue considering a best practice(other solutions) for this.

* If JDK 8 is used, maven build perform by 1 step as same with other module.

* If JDK 7 is used, maven build perform by 2 stop. 
    - It perform maven install using JDK 8, `terasoluna-gfw-validator` install to the maven local repository. (If define `'JAVA8_PLUS_HOME'` environment variable, this step is enabled). 
    - It perform maven test without JSR-310 tests. `terasoluna-gfw-validator`(test target module) get from the maven local repository.

In this PR, https://github.com/terasolunaorg/terasoluna-gfw/tree/master/terasoluna-gfw-validator/test not used. These test projects are necessary ?

Please review #372 .
