### PR TITLE
Remove RIGHT_PROPERTY from Node #372

### DIFF
--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -81,7 +81,7 @@ public @interface Compare {
     /**
      * @return node of bind validation message
      */
-    Node node() default Node.LEFT_PROPERTY;
+    Node node() default Node.PROPERTY;
 
     /**
      * Defines several {@link Compare} annotations on the same element.
@@ -217,12 +217,7 @@ public @interface Compare {
         /**
          * Bind validation message to property specified {@code Compare#left()}.
          */
-        LEFT_PROPERTY,
-
-        /**
-         * Bind validation message to property specified {@code Compare#right()}.
-         */
-        RIGHT_PROPERTY,
+        PROPERTY,
 
         /**
          * Bind validation message to root bean {@code Compare} annotated.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -79,9 +79,9 @@ public @interface Compare {
     Operator operator();
 
     /**
-     * @return property path of bind validation message
+     * @return node of bind validation message
      */
-    Path path() default Path.LEFT;
+    Node node() default Node.LEFT_PROPERTY;
 
     /**
      * Defines several {@link Compare} annotations on the same element.
@@ -209,20 +209,20 @@ public @interface Compare {
     }
 
     /**
-     * The property path of bind validation message.
+     * The node of bind validation message.
      * @since 5.1.0
      */
-    enum Path {
+    enum Node {
 
         /**
          * Bind validation message to property specified {@code Compare#left()}.
          */
-        LEFT,
+        LEFT_PROPERTY,
 
         /**
          * Bind validation message to property specified {@code Compare#right()}.
          */
-        RIGHT,
+        RIGHT_PROPERTY,
 
         /**
          * Bind validation message to root bean {@code Compare} annotated.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/CompareValidator.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/CompareValidator.java
@@ -134,7 +134,7 @@ public class CompareValidator implements ConstraintValidator<Compare, Object> {
     }
 
     /**
-     * Construct validation message when selected {@link Node#LEFT_PROPERTY} or {@link Node#RIGHT_PROPERTY}.
+     * Construct validation message when selected {@link Node#PROPERTY}.
      * @param context constraint validation context
      */
     private void constructValidationMessage(ConstraintValidatorContext context) {
@@ -142,9 +142,8 @@ public class CompareValidator implements ConstraintValidator<Compare, Object> {
             return;
         }
 
-        String propertyName = (node == Node.LEFT_PROPERTY) ? left : right;
         context.buildConstraintViolationWithTemplate(message).addPropertyNode(
-                propertyName).addConstraintViolation()
+                left).addConstraintViolation()
                 .disableDefaultConstraintViolation();
     }
 }

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/CompareValidator.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/CompareValidator.java
@@ -22,8 +22,8 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import org.terasoluna.gfw.common.validator.constraints.Compare;
+import org.terasoluna.gfw.common.validator.constraints.Compare.Node;
 import org.terasoluna.gfw.common.validator.constraints.Compare.Operator;
-import org.terasoluna.gfw.common.validator.constraints.Compare.Path;
 
 /**
  * Constraint validator class of {@link Compare} annotation.
@@ -52,9 +52,9 @@ public class CompareValidator implements ConstraintValidator<Compare, Object> {
     private Operator operator;
 
     /**
-     * Property path of bind validation message
+     * Node of bind validation message
      */
-    private Path path;
+    private Node node;
 
     /**
      * Validation message.
@@ -71,7 +71,7 @@ public class CompareValidator implements ConstraintValidator<Compare, Object> {
         left = constraintAnnotation.left();
         right = constraintAnnotation.right();
         operator = constraintAnnotation.operator();
-        path = constraintAnnotation.path();
+        node = constraintAnnotation.node();
         message = constraintAnnotation.message();
     }
 
@@ -134,17 +134,17 @@ public class CompareValidator implements ConstraintValidator<Compare, Object> {
     }
 
     /**
-     * Construct validation message when selected {@code PropertyPath#LEFT} or {@code PropertyPath#RIGHT}.
+     * Construct validation message when selected {@link Node#LEFT_PROPERTY} or {@link Node#RIGHT_PROPERTY}.
      * @param context constraint validation context
      */
     private void constructValidationMessage(ConstraintValidatorContext context) {
-        if (path == Path.ROOT_BEAN) {
+        if (node == Node.ROOT_BEAN) {
             return;
         }
 
-        String node = (path == Path.LEFT) ? left : right;
+        String propertyName = (node == Node.LEFT_PROPERTY) ? left : right;
         context.buildConstraintViolationWithTemplate(message).addPropertyNode(
-                node).addConstraintViolation()
+                propertyName).addConstraintViolation()
                 .disableDefaultConstraintViolation();
     }
 }

--- a/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
+++ b/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
@@ -278,7 +278,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         form.setLeft(100);
         form.setRight(99);
 
-        violations = validator.validate(form, NodeLeftProperty.class);
+        violations = validator.validate(form, NodeProperty.class);
         assertThat(violations.size(), is(1));
         for (ConstraintViolation<CompareTestForm> violation : violations) {
             assertThat(violation.getMessage(), is(String.format(
@@ -286,28 +286,6 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             for (javax.validation.Path.Node node : violation.getPropertyPath()) {
                 assertThat(node, instanceOf(PropertyNode.class));
                 assertThat(node.getName(), is("left"));
-            }
-        }
-    }
-
-    /**
-     * specify path. expected validation message node is right.
-     * @throws Throwable
-     */
-    @Test
-    public void testSpecifyPathRight() throws Throwable {
-
-        form.setLeft(100);
-        form.setRight(99);
-
-        violations = validator.validate(form, NodeRightProperty.class);
-        assertThat(violations.size(), is(1));
-        for (ConstraintViolation<CompareTestForm> violation : violations) {
-            assertThat(violation.getMessage(), is(String.format(
-                    MESSAGE_VALIDATION_ERROR, "left", "right")));
-            for (javax.validation.Path.Node node : violation.getPropertyPath()) {
-                assertThat(node, instanceOf(PropertyNode.class));
-                assertThat(node.getName(), is("right"));
             }
         }
     }
@@ -419,13 +397,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
     /**
      * Validation group path left.
      */
-    private static interface NodeLeftProperty {
-    };
-
-    /**
-     * Validation group path right.
-     */
-    private static interface NodeRightProperty {
+    private static interface NodeProperty {
     };
 
     /**
@@ -464,8 +436,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             @Compare(left = "left", right = "right", operator = Operator.GRATER_THAN, groups = { GraterThan.class }),
             @Compare(left = "left", right = "right", operator = Operator.LESS_THAN_OR_EQUAL, groups = { LessThanOrEqual.class }),
             @Compare(left = "left", right = "right", operator = Operator.LESS_THAN, groups = { LessThan.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.LEFT_PROPERTY, groups = { NodeLeftProperty.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.RIGHT_PROPERTY, groups = { NodeRightProperty.class }),
+            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.PROPERTY, groups = { NodeProperty.class }),
             @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.ROOT_BEAN, groups = { PathRootBean.class }),
             @Compare(left = "left", right = "stringProperty", operator = Operator.EQUAL, groups = { TypeUnmatch.class }),
             @Compare(left = "unknown", right = "right", operator = Operator.EQUAL, groups = { UnknownLeft.class }),

--- a/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
+++ b/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
@@ -23,13 +23,12 @@ import static org.junit.Assert.assertThat;
 import java.beans.IntrospectionException;
 
 import javax.validation.ConstraintViolation;
-import javax.validation.Path.Node;
 import javax.validation.Path.PropertyNode;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.terasoluna.gfw.common.validator.constraints.Compare.Node;
 import org.terasoluna.gfw.common.validator.constraints.Compare.Operator;
-import org.terasoluna.gfw.common.validator.constraints.Compare.Path;
 import org.terasoluna.gfw.common.validator.constraints.CompareTest.CompareTestForm;
 
 /**
@@ -279,12 +278,12 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         form.setLeft(100);
         form.setRight(99);
 
-        violations = validator.validate(form, PathLeft.class);
+        violations = validator.validate(form, NodeLeftProperty.class);
         assertThat(violations.size(), is(1));
         for (ConstraintViolation<CompareTestForm> violation : violations) {
             assertThat(violation.getMessage(), is(String.format(
                     MESSAGE_VALIDATION_ERROR, "left", "right")));
-            for (Node node : violation.getPropertyPath()) {
+            for (javax.validation.Path.Node node : violation.getPropertyPath()) {
                 assertThat(node, instanceOf(PropertyNode.class));
                 assertThat(node.getName(), is("left"));
             }
@@ -301,12 +300,12 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         form.setLeft(100);
         form.setRight(99);
 
-        violations = validator.validate(form, PathRight.class);
+        violations = validator.validate(form, NodeRightProperty.class);
         assertThat(violations.size(), is(1));
         for (ConstraintViolation<CompareTestForm> violation : violations) {
             assertThat(violation.getMessage(), is(String.format(
                     MESSAGE_VALIDATION_ERROR, "left", "right")));
-            for (Node node : violation.getPropertyPath()) {
+            for (javax.validation.Path.Node node : violation.getPropertyPath()) {
                 assertThat(node, instanceOf(PropertyNode.class));
                 assertThat(node.getName(), is("right"));
             }
@@ -328,7 +327,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         for (ConstraintViolation<CompareTestForm> violation : violations) {
             assertThat(violation.getMessage(), is(String.format(
                     MESSAGE_VALIDATION_ERROR, "left", "right")));
-            for (Node node : violation.getPropertyPath()) {
+            for (javax.validation.Path.Node node : violation.getPropertyPath()) {
                 assertThat(node, instanceOf(PropertyNode.class));
                 assertThat(node.getName(), nullValue());
             }
@@ -420,13 +419,13 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
     /**
      * Validation group path left.
      */
-    private static interface PathLeft {
+    private static interface NodeLeftProperty {
     };
 
     /**
      * Validation group path right.
      */
-    private static interface PathRight {
+    private static interface NodeRightProperty {
     };
 
     /**
@@ -465,9 +464,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             @Compare(left = "left", right = "right", operator = Operator.GRATER_THAN, groups = { GraterThan.class }),
             @Compare(left = "left", right = "right", operator = Operator.LESS_THAN_OR_EQUAL, groups = { LessThanOrEqual.class }),
             @Compare(left = "left", right = "right", operator = Operator.LESS_THAN, groups = { LessThan.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, path = Path.LEFT, groups = { PathLeft.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, path = Path.RIGHT, groups = { PathRight.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, path = Path.ROOT_BEAN, groups = { PathRootBean.class }),
+            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.LEFT_PROPERTY, groups = { NodeLeftProperty.class }),
+            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.RIGHT_PROPERTY, groups = { NodeRightProperty.class }),
+            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.ROOT_BEAN, groups = { PathRootBean.class }),
             @Compare(left = "left", right = "stringProperty", operator = Operator.EQUAL, groups = { TypeUnmatch.class }),
             @Compare(left = "unknown", right = "right", operator = Operator.EQUAL, groups = { UnknownLeft.class }),
             @Compare(left = "left", right = "unknown", operator = Operator.EQUAL, groups = { UnknownRight.class }),


### PR DESCRIPTION
I've refactor Node enum.

I think `RIGHT`(`RIGHT_PROPERTY`) is unnecessary option.
If want to bind to right property, it can be realized by reversing left and right.
Hence, i've removed `RIGHT`(`RIGHT_PROPERTY`).

Please review #372 .

**Note:**
At first, please review #413.