### PR TITLE
Update to Spring 3.2.16.RELEASE #391

### DIFF
--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -1001,7 +1001,7 @@
         <ch.qos.logback.version>1.0.13</ch.qos.logback.version>
         <org.lazyluke.version>0.2.7</org.lazyluke.version>
         <!-- == Spring Framework == -->
-        <org.springframework-version>3.2.14.RELEASE</org.springframework-version>
+        <org.springframework-version>3.2.16.RELEASE</org.springframework-version>
         <org.springframework.data.spring-data-jpa.version>1.4.3.RELEASE</org.springframework.data.spring-data-jpa.version>
         <org.springframework.data.version>1.6.4.RELEASE</org.springframework.data.version>
         <org.springframework.security.version>3.1.4.RELEASE</org.springframework.security.version>


### PR DESCRIPTION
* Apply fix version for CVE-2015-5211

Please review #391 .

**Note:**

CI of functional tests and Sample application has been succeeded using Spring 3.2.16.

* https://travis-ci.org/terasolunaorg/terasoluna-gfw-functionaltest/builds/97594180
* https://travis-ci.org/terasolunaorg/terasoluna-tourreservation/builds/97597601


