### PR TITLE
Update to Spring IO Platform 1.1.5 #392

### DIFF
--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -516,7 +516,7 @@
         <!-- == TERASOLUNA == -->
         <terasoluna.gfw.version>5.0.2-SNAPSHOT</terasoluna.gfw.version>
         <!-- == Spring IO Platform == -->
-        <io.spring.platform.version>1.1.3.RELEASE</io.spring.platform.version>
+        <io.spring.platform.version>1.1.5.RELEASE</io.spring.platform.version>
         <!-- == MyBatis3 == -->
         <org.mybatis.version>3.2.8</org.mybatis.version>
         <org.mybatis.spring.version>1.2.2</org.mybatis.spring.version>


### PR DESCRIPTION
* Apply fix version for CVE-2015-5211
* Apply fix version for COLLECTIONS-580

Please review #392 .

**Note:**
CI of functional tests and sample application has been succeeded using Spring IO Platform 1.1.5.

* https://travis-ci.org/terasolunaorg/terasoluna-gfw-functionaltest/builds/97815198
* https://travis-ci.org/terasolunaorg/terasoluna-tourreservation/builds/97815484
* https://travis-ci.org/terasolunaorg/terasoluna-tourreservation-mybatis3/builds/97816329