### PR TITLE
add missing javadoc in constraint annotations #372

### DIFF
--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
@@ -56,10 +56,22 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.ByteMaxValidator
 @Retention(RUNTIME)
 public @interface ByteMax {
 
+    /**
+     * Error message or message key
+     * @return error message or message key
+     */
     String message() default "{org.terasoluna.gfw.common.validator.constraints.ByteMax.message}";
 
+    /**
+     * Constraint groups
+     * @return constraint groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * Payload
+     * @return payload
+     */
     Class<? extends Payload>[] payload() default {};
 
     /**

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
@@ -56,10 +56,22 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.ByteMinValidator
 @Retention(RUNTIME)
 public @interface ByteMin {
 
+    /**
+     * Error message or message key
+     * @return error message or message key
+     */
     String message() default "{org.terasoluna.gfw.common.validator.constraints.ByteMin.message}";
 
+    /**
+     * Constraint groups
+     * @return constraint groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * Payload
+     * @return payload
+     */
     Class<? extends Payload>[] payload() default {};
 
     /**

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -57,10 +57,22 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.CompareValidator
 @Retention(RUNTIME)
 public @interface Compare {
 
+    /**
+     * Error message or message key
+     * @return error message or message key
+     */
     String message() default "{org.terasoluna.gfw.common.validator.constraints.Compare.message}";
 
+    /**
+     * Constraint groups
+     * @return constraint groups
+     */
     Class<?>[] groups() default {};
 
+    /**
+     * Payload
+     * @return payload
+     */
     Class<? extends Payload>[] payload() default {};
 
     /**


### PR DESCRIPTION
Sorry, I've added missing javadoc in `terasoluna-gfw-validator` constraint annotations.
Please, review #372.