### PR TITLE
add missing javadoc in constraint annotations #372

### DIFF
--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
@@ -93,6 +93,10 @@ public @interface ByteMax {
     @Target({ METHOD, FIELD, TYPE, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
     @Retention(RUNTIME)
     @interface List {
+        /**
+         * <code>@ByteMax</code> annotations
+         * @return annotations
+         */
         ByteMax[] value();
     }
 }

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
@@ -93,6 +93,10 @@ public @interface ByteMin {
     @Target({ METHOD, FIELD, TYPE, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
     @Retention(RUNTIME)
     @interface List {
+        /**
+         * <code>@ByteMin</code> annotations
+         * @return annotations
+         */
         ByteMin[] value();
     }
 }

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -111,6 +111,10 @@ public @interface Compare {
     @Target({ METHOD, FIELD, TYPE, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
     @Retention(RUNTIME)
     @interface List {
+        /**
+         * <code>@Compare</code> annotations
+         * @return annotations
+         */
         Compare[] value();
     }
 


### PR DESCRIPTION
I've added remaining `3` missing javadocs.
I hope that the coverage problem is resolved.
Sorry, please merge #372.