### PR TITLE
change to '2013-2016 NTT DATA Corporation' from '2013-2016  NTT DATA …

### DIFF
--- a/license/header.txt
+++ b/license/header.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2016  NTT DATA Corporation
+Copyright (C) 2013-2016 NTT DATA Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_Katakana.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_Katakana.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_LatinLetters.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_LatinLetters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_KatakanaTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_KatakanaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_LatinLettersTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0201_LatinLettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_BoxDrawingChars.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_BoxDrawingChars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_CyrillicLetters.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_CyrillicLetters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_GreekLetters.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_GreekLetters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_Hiragana.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_Hiragana.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_Katakana.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_Katakana.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_LatinLetters.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_LatinLetters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_SpecialChars.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_SpecialChars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_BoxDrawingCharsTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_BoxDrawingCharsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_CyrillicLettersTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_CyrillicLettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_GreekLettersTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_GreekLettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_HiraganaTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_HiraganaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_KatakanaTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_KatakanaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_LatinLettersTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_LatinLettersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_SpecialCharsTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_SpecialCharsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208kanji/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_Kanji.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208kanji/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_Kanji.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208kanji/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_KanjiTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208kanji/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0208_KanjiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0213kanji/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0213_Kanji.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0213kanji/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0213_Kanji.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0213kanji/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0213_KanjiTest.java
+++ b/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0213kanji/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/JIS_X_0213_KanjiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/CodePoints.java
+++ b/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/CodePoints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/ConsistOf.java
+++ b/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/ConsistOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIControlChars.java
+++ b/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIControlChars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIPrintableChars.java
+++ b/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIPrintableChars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/CRLF.java
+++ b/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/catalog/CRLF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidator.java
+++ b/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/CodePointsTest.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/CodePointsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/ABCD.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/ABCD.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIControlCharsTest.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIControlCharsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIPrintableCharsTest.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/ASCIIPrintableCharsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/AbstractCodePoints.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/AbstractCodePoints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/CRLFTest.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/CRLFTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/IllegalCodePoints.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/catalog/IllegalCodePoints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/AsciiPrintable.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/AsciiPrintable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/AtoF.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/AtoF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/AtoL.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/AtoL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/GtoL.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/GtoL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Annotation.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Annotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Composite.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Composite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_ConstructorParameter.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_ConstructorParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Getter.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Getter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Multi.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Multi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Simple.java
+++ b/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/Name_Simple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/AbstractCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/AbstractCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/AbstractReloadableCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/AbstractReloadableCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/CodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/CodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/EnumCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/EnumCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ExistInCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ExistInCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/JdbcCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/JdbcCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ReadWriteLockMapWrapper.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ReadWriteLockMapWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ReloadableCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ReloadableCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/SimpleMapCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/SimpleMapCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/AbstractI18nCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/AbstractI18nCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/I18nCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/I18nCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/SimpleI18nCodeList.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/SimpleI18nCodeList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/AbstractExistInCodeListValidator.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/AbstractExistInCodeListValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/ExistInCodeListValidatorForCharSequence.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/ExistInCodeListValidatorForCharSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/ExistInCodeListValidatorForCharacter.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/ExistInCodeListValidatorForCharacter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/ClassicDateFactory.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/ClassicDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DefaultClassicDateFactory.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DefaultClassicDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/BusinessException.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/BusinessException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/DefaultExceptionLevelResolver.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/DefaultExceptionLevelResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionCodeProvider.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionCodeProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionCodeResolver.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionCodeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLevel.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLevelResolver.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLevelResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLogger.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ResourceNotFoundException.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ResourceNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptor.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ResultMessagesNotificationException.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ResultMessagesNotificationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/SimpleMappingExceptionCodeResolver.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/SimpleMappingExceptionCodeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/SystemException.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/SystemException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessage.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessageType.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessageUtils.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessageUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessages.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/ResultMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/StandardResultMessageType.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/StandardResultMessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/LikeConditionEscape.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/LikeConditionEscape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/QueryEscapeUtils.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/QueryEscapeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/JdbcSequencer.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/JdbcSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/Sequencer.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/Sequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/package-info.java
+++ b/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/AbstractReloadableCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/AbstractReloadableCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/EnumCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/EnumCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/JdbcCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/JdbcCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ReadWriteLockMapWrapperTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ReadWriteLockMapWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/SimpleMapCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/SimpleMapCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/AbstractI18nCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/AbstractI18nCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/SimpleI18nCodeListTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/SimpleI18nCodeListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DateConvertUtilsTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DateConvertUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DateTime.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DefaultClassicDateFactoryTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DefaultClassicDateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/DefaultExceptionLevelResolverTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/DefaultExceptionLevelResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptorTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/SimpleMappingExceptionCodeResolverTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/SimpleMappingExceptionCodeResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/SystemExceptionTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/SystemExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/test/TestFacade.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/test/TestFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/test/TestRepository.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/test/TestRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/test/TestService.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/test/TestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageUtilsTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessagesTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessagesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/StandardResultMessageTypeTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/StandardResultMessageTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/query/QueryEscapeUtilsTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/query/QueryEscapeUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/sequencer/JdbcSequencerTest.java
+++ b/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/sequencer/JdbcSequencerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/AbstractDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/AbstractDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/DateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/DateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/DefaultDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/DefaultDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/JdbcAdjustedDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/JdbcAdjustedDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/JdbcFixedDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/JdbcFixedDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/AbstractJodaTimeDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/AbstractJodaTimeDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/DefaultJodaTimeDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/DefaultJodaTimeDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JdbcAdjustedJodaTimeDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JdbcAdjustedJodaTimeDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JdbcFixedJodaTimeDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JdbcFixedJodaTimeDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateTimeFactory.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateTimeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/package-info.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/package-info.java
+++ b/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/AbstractJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/AbstractJodaTimeDateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/DefaultJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/DefaultJodaTimeDateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcAdjustedJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcAdjustedJodaTimeDateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcFixedJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcFixedJodaTimeDateFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/logging/UserIdMDCPutFilter.java
+++ b/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/logging/UserIdMDCPutFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/logging/package-info.java
+++ b/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/logging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/redirect/RedirectAuthenticationHandler.java
+++ b/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/redirect/RedirectAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/redirect/package-info.java
+++ b/terasoluna-gfw-security-web/src/main/java/org/terasoluna/gfw/security/web/redirect/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-security-web/src/test/java/org/terasoluna/gfw/security/web/logging/UserIdMDCPutFilterTest.java
+++ b/terasoluna-gfw-security-web/src/test/java/org/terasoluna/gfw/security/web/logging/UserIdMDCPutFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-security-web/src/test/java/org/terasoluna/gfw/security/web/redirect/RedirectAuthenticationHandlerTest.java
+++ b/terasoluna-gfw-security-web/src/test/java/org/terasoluna/gfw/security/web/redirect/RedirectAuthenticationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalf.java
+++ b/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfConverter.java
+++ b/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfPair.java
+++ b/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfPair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairs.java
+++ b/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsBuilder.java
+++ b/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfConverterTest.java
+++ b/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsBuilderTest.java
+++ b/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsTest.java
+++ b/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/ToFullwidthTest.java
+++ b/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/ToFullwidthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/ToHalfwidthTest.java
+++ b/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/ToHalfwidthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/package-info.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ByteMaxValidator.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ByteMaxValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ByteMinValidator.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ByteMinValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/CompareValidator.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/CompareValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ConstraintValidatorsUtils.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ConstraintValidatorsUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/package-info.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/package-info.java
+++ b/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/AbstractConstraintsTest.java
+++ b/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/AbstractConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMaxTest.java
+++ b/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMaxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMinTest.java
+++ b/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
+++ b/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/MessagesPanelTag.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/MessagesPanelTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/package-info.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTag.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/util/JspTagUtils.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/util/JspTagUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/util/package-info.java
+++ b/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
+++ b/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTagTest.java
+++ b/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTagTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/util/JspTagUtilsTest.java
+++ b/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/util/JspTagUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/CodeListInterceptor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/CodeListInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/ObjectToMapConverter.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/ObjectToMapConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilter.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/SystemExceptionResolver.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/SystemExceptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListener.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/AbstractMDCPutFilter.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/AbstractMDCPutFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/MDCClearFilter.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/MDCClearFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/XTrackMDCPutFilter.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/XTrackMDCPutFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/ProcessActionInvocationHelper.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/ProcessActionInvocationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/RequestDataValueProcessorAdaptor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/RequestDataValueProcessorAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/PaginationInfo.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/PaginationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/TokenStringGenerator.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/TokenStringGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStore.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/InvalidTransactionTokenException.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/InvalidTransactionTokenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionToken.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenCheck.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContext.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextHandlerMethodArgumentResolver.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextHandlerMethodArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImpl.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfo.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoStore.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenRequestDataValueProcessor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenRequestDataValueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenStore.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenType.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/HtmlEscapeUtils.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/HtmlEscapeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/RequestUtils.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/RequestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/ResponseUtils.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/ResponseUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/package-info.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/download/FileDownloadViewTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/download/FileDownloadViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/ObjectToMapConverterTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/ObjectToMapConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilterTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/SystemExceptionResolverTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/SystemExceptionResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/SampleForm.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/SampleForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptorController.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptorController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/AbstractMDCPutFilterTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/AbstractMDCPutFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/MDCClearFilterTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/MDCClearFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/XTrackMDCPutFilterTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/XTrackMDCPutFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/RequestDataValueProcessorAdaptorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/RequestDataValueProcessorAdaptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationInfoTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/TokenStringGeneratorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/TokenStringGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStoreTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/InvalidTransactionTokenExceptionTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/InvalidTransactionTokenExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/SampleForm.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/SampleForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextHandlerMethodArgumentResolverTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextHandlerMethodArgumentResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImplTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoStoreTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenRequestDataValueProcessorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenRequestDataValueProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenSampleController.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenSampleController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenSampleNamespaceController.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenSampleNamespaceController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/RequestUtilsTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/RequestUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/ResponseUtilsTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/ResponseUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2016  NTT DATA Corporation
+ * Copyright (C) 2013-2016 NTT DATA Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Please review #528
 * mistake: `2013-2016　NTT DATA Corporation`
 * correct : `2013-2016 NTT DATA Corporation`