### PR TITLE
[5.1.x] TransactionTokenContext deprecated. #593

### DIFF
--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContext.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContext.java
@@ -22,12 +22,14 @@ public interface TransactionTokenContext {
 
     /**
      * Defines the contract for implementations of token creation
+     * @deprecated not work properly
      */
     @Deprecated
     void createToken();
 
     /**
      * Defines the contract for implementations of token removal
+     * @deprecated not work properly
      */
     @Deprecated
     void removeToken();

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContext.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContext.java
@@ -23,11 +23,13 @@ public interface TransactionTokenContext {
     /**
      * Defines the contract for implementations of token creation
      */
+    @Deprecated
     void createToken();
 
     /**
      * Defines the contract for implementations of token removal
      */
+    @Deprecated
     void removeToken();
 
     /**

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImpl.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImpl.java
@@ -80,6 +80,7 @@ public class TransactionTokenContextImpl implements TransactionTokenContext {
      * If the <code>receivedToken</code> contains a valid token, sets the instruction to create a new
      * <code>TransactionToken</code>
      * @see org.terasoluna.gfw.web.token.transaction.TransactionTokenContext#createToken()
+     * @deprecated not work properly
      */
     @Deprecated
     @Override
@@ -95,6 +96,7 @@ public class TransactionTokenContextImpl implements TransactionTokenContext {
      * set reserveCommand to
      * {@link org.terasoluna.gfw.web.token.transaction.TransactionTokenContextImpl.ReserveCommand#REMOVE_TOKEN}
      * @see org.terasoluna.gfw.web.token.transaction.TransactionTokenContext#removeToken()
+     * @deprecated not work properly
      */
     @Deprecated
     @Override
@@ -104,6 +106,7 @@ public class TransactionTokenContextImpl implements TransactionTokenContext {
 
     /**
      * rollback resrveCommand to default
+     * @deprecated not work properly
      */
     @Deprecated
     public void cancelReservation() {

--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImpl.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextImpl.java
@@ -81,6 +81,7 @@ public class TransactionTokenContextImpl implements TransactionTokenContext {
      * <code>TransactionToken</code>
      * @see org.terasoluna.gfw.web.token.transaction.TransactionTokenContext#createToken()
      */
+    @Deprecated
     @Override
     public void createToken() {
         if (receivedToken.valid()) {
@@ -95,6 +96,7 @@ public class TransactionTokenContextImpl implements TransactionTokenContext {
      * {@link org.terasoluna.gfw.web.token.transaction.TransactionTokenContextImpl.ReserveCommand#REMOVE_TOKEN}
      * @see org.terasoluna.gfw.web.token.transaction.TransactionTokenContext#removeToken()
      */
+    @Deprecated
     @Override
     public void removeToken() {
         reserveCommand = ReserveCommand.REMOVE_TOKEN;
@@ -103,6 +105,7 @@ public class TransactionTokenContextImpl implements TransactionTokenContext {
     /**
      * rollback resrveCommand to default
      */
+    @Deprecated
     public void cancelReservation() {
         reserveCommand = defaultCommand;
     }


### PR DESCRIPTION
Please review #593 .
Cherry-picked from #594 .
