### PR TITLE
[5.1.x] Fix TransactionTokenInterceptor throws NPE when an Exception is thrown in preHandle. #564

### DIFF
--- a/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptor.java
+++ b/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptor.java
@@ -326,8 +326,10 @@ public class TransactionTokenInterceptor implements HandlerInterceptor {
         if (ex != null) {
             TransactionTokenContextImpl tokenContext = (TransactionTokenContextImpl) request
                     .getAttribute(TOKEN_CONTEXT_REQUEST_ATTRIBUTE_NAME);
-            TransactionToken token = tokenContext.getReceivedToken();
-            removeToken(token);
+            if (tokenContext != null) {
+                TransactionToken token = tokenContext.getReceivedToken();
+                removeToken(token);
+            }
         }
 
     }

--- a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
+++ b/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
@@ -680,6 +680,16 @@ public class TransactionTokenInterceptorTest {
         }
     }
 
+    @Test
+    public void testAfterCompletionWithExceptionHasNoTransactionTokenContextImpl() {
+        try {
+            interceptor.afterCompletion(request, response, null, new Exception());
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    
     /*
      * @Test public void testCreateTokenSynchronization() throws Exception { int size = 2000; Thread arrThreads[] = new
      * Thread[size]; for (int i = 0; i <size ; i++) { Thread thread = new Thread(new Runnable() {


### PR DESCRIPTION
Please review #564.

(cherry picked from commit 851cab172ac72a671e65a98bb1f2e006dae557d9)