### PR TITLE
[5.1.x]Drop oraclejdk7 from .travis.yml #666

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 
 cache:


### PR DESCRIPTION
(cherry picked from commit 2bf60c0d4361ae936fdaf8adc18ee1cab36f194d)

Please review #666.
