### PR TITLE
[5.0.x]Drop oraclejdk7 and openjdk6 from ".travis.yml". #666 and #725

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk7
-  - openjdk6
 
 cache:
   directories:
@@ -13,6 +12,6 @@ install: true
 
 script:
   - ./mvn-build-all.sh xml:check-format
-  - if [[ $TRAVIS_JDK_VERSION != "openjdk6" ]]; then ./mvn-build-all.sh formatter:validate; fi
+  - ./mvn-build-all.sh formatter:validate
   - ./mvn-build-all.sh clean install jacoco:report
-  - if [[ $TRAVIS_JDK_VERSION != "openjdk6" ]]; then mvn -U coveralls:report -f terasoluna-gfw-parent/pom.xml; fi
+  - mvn -U coveralls:report -f terasoluna-gfw-parent/pom.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
   - openjdk6
 


### PR DESCRIPTION
Please review #666 and #725 .