### PR TITLE
[5.5.0.RC2]Upgrade to spring io platform Cairo-SR1. #810

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk8
-  - openjdk7
 
 cache:
   directories:

--- a/terasoluna-gfw-common-libraries/pom.xml
+++ b/terasoluna-gfw-common-libraries/pom.xml
@@ -165,7 +165,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <archetype.test.skip>true</archetype.test.skip>
     <encoding>UTF-8</encoding>
-    <java-version>1.7</java-version>
+    <java-version>1.8</java-version>
     <project.root.basedir>${project.basedir}</project.root.basedir>
   </properties>
 </project>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java
@@ -775,24 +775,23 @@ public class ExceptionLoggerTest {
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return ((LoggingEvent) argument).getFormattedMessage()
-                                .equals(expectedLogMessage);
+                    public boolean matches(LoggingEvent argument) {
+                        return argument.getFormattedMessage().equals(
+                                expectedLogMessage);
                     }
                 }));
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return expectedLogLevel.equals(((LoggingEvent) argument)
-                                .getLevel());
+                    public boolean matches(LoggingEvent argument) {
+                        return expectedLogLevel.equals(argument.getLevel());
                     }
                 }));
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        LoggingEvent loggingEvent = (LoggingEvent) argument;
+                    public boolean matches(LoggingEvent argument) {
+                        LoggingEvent loggingEvent = argument;
                         if (expectedException == null) {
                             return loggingEvent.getThrowableProxy() == null;
                         }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java
@@ -18,7 +18,7 @@ package org.terasoluna.gfw.common.exception;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -308,8 +308,8 @@ public class ExceptionLoggerTest {
         String expectedLogMessage = "[code01] system error.";
         verifyLogging(expectedLogMessage, Level.WARN, ex,
                 mockApplicationLoggerAppender);
-        verify(mockMonitoringLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockMonitoringLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
     }
 
     @Test
@@ -331,8 +331,8 @@ public class ExceptionLoggerTest {
 
         // do assert.
         String expectedLogMessage = "[code01] system error.";
-        verify(mockApplicationLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockApplicationLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
         verifyLogging(expectedLogMessage, Level.WARN,
                 mockMonitoringLoggerAppender);
 
@@ -356,10 +356,10 @@ public class ExceptionLoggerTest {
         testTarget.warn(ex);
 
         // do assert.
-        verify(mockApplicationLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
-        verify(mockMonitoringLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockApplicationLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
+        verify(mockMonitoringLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
 
     }
 
@@ -410,8 +410,8 @@ public class ExceptionLoggerTest {
         String expectedLogMessage = "[code01] system error.";
         verifyLogging(expectedLogMessage, Level.ERROR, ex,
                 mockApplicationLoggerAppender);
-        verify(mockMonitoringLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockMonitoringLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
     }
 
     @Test
@@ -433,8 +433,8 @@ public class ExceptionLoggerTest {
 
         // do assert.
         String expectedLogMessage = "[code01] system error.";
-        verify(mockApplicationLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockApplicationLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
         verifyLogging(expectedLogMessage, Level.ERROR,
                 mockMonitoringLoggerAppender);
 
@@ -458,10 +458,10 @@ public class ExceptionLoggerTest {
         testTarget.error(ex);
 
         // do assert.
-        verify(mockApplicationLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
-        verify(mockMonitoringLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockApplicationLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
+        verify(mockMonitoringLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
 
     }
 
@@ -565,8 +565,8 @@ public class ExceptionLoggerTest {
         String expectedLogMessage = "[code01] system error.";
         verifyLogging(expectedLogMessage, Level.INFO, ex,
                 mockApplicationLoggerAppender);
-        verify(mockMonitoringLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockMonitoringLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
     }
 
     @Test
@@ -588,8 +588,8 @@ public class ExceptionLoggerTest {
 
         // do assert.
         String expectedLogMessage = "[code01] system error.";
-        verify(mockApplicationLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockApplicationLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
         verifyLogging(expectedLogMessage, Level.INFO,
                 mockMonitoringLoggerAppender);
 
@@ -613,10 +613,10 @@ public class ExceptionLoggerTest {
         testTarget.info(ex);
 
         // do assert.
-        verify(mockApplicationLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
-        verify(mockMonitoringLoggerAppender, times(0)).doAppend(
-                (ILoggingEvent) anyObject());
+        verify(mockApplicationLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
+        verify(mockMonitoringLoggerAppender, times(0)).doAppend(any(
+                ILoggingEvent.class));
 
     }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptorTest.java
@@ -19,8 +19,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -126,7 +125,7 @@ public class ResultMessagesLoggingInterceptorTest extends
             // do assert.
             assertThat(e, is(occurException));
             verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
         }
 
     }
@@ -157,7 +156,7 @@ public class ResultMessagesLoggingInterceptorTest extends
             // do assert.
             assertThat(e, is(occurException));
             verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
         }
 
     }
@@ -177,7 +176,7 @@ public class ResultMessagesLoggingInterceptorTest extends
             // do assert.
             assertThat(e, is(occurException));
             verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
         }
 
     }
@@ -201,7 +200,7 @@ public class ResultMessagesLoggingInterceptorTest extends
             // do assert.
             assertThat(e, is(occurException));
             verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
         }
 
     }
@@ -241,7 +240,7 @@ public class ResultMessagesLoggingInterceptorTest extends
             // do assert.
             assertThat(e, is(occurException));
             verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
         }
 
     }
@@ -266,7 +265,7 @@ public class ResultMessagesLoggingInterceptorTest extends
             // do assert.
             assertThat(e, is(occurException));
             verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
         }
 
     }
@@ -295,7 +294,7 @@ public class ResultMessagesLoggingInterceptorTest extends
         } catch (NullPointerException e) {
             // do assert.
             assertThat(e, is(occurException));
-            verify(mockExceptionLogger, never()).warn((Exception) anyObject());
+            verify(mockExceptionLogger, never()).warn(any(Exception.class));
         }
 
     }
@@ -339,7 +338,7 @@ public class ResultMessagesLoggingInterceptorTest extends
 
         // do assert.
         verify(mockExceptionLogger, times(2)).warn(occurException);
-        verify(mockExceptionLogger, times(2)).warn((Exception) anyObject());
+        verify(mockExceptionLogger, times(2)).warn(any(Exception.class));
 
     }
 
@@ -471,7 +470,7 @@ public class ResultMessagesLoggingInterceptorTest extends
 
         verify(mockExceptionLogger, times(1)).warn(occurExceptionForThread1);
         verify(mockExceptionLogger, times(1)).warn(occurExceptionForThread2);
-        verify(mockExceptionLogger, times(2)).warn((Exception) anyObject());
+        verify(mockExceptionLogger, times(2)).warn(any(Exception.class));
     }
 
     /**
@@ -540,7 +539,7 @@ public class ResultMessagesLoggingInterceptorTest extends
                 occurExceptionForThread2));
 
         verify(mockExceptionLogger, times(1)).warn(occurExceptionForThread2);
-        verify(mockExceptionLogger, times(1)).warn((Exception) anyObject());
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
@@ -18,8 +18,8 @@ package org.terasoluna.gfw.web.message;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -72,10 +72,10 @@ public class MessagesPanelTagTest {
     protected MockPageContext createPageContext() {
         MockServletContext sc = new MockServletContext();
         wac = mock(WebApplicationContext.class);
-        when(wac.getMessage(eq("hello.world"), eq(new Object[] {}),
-                (Locale) anyObject())).thenReturn("hello world!");
-        when(wac.getMessage(eq("foo.bar"), eq(new Object[] { 1, 2 }),
-                (Locale) anyObject())).thenReturn("foo1 and bar2");
+        when(wac.getMessage(eq("hello.world"), eq(new Object[] {}), any(
+                Locale.class))).thenReturn("hello world!");
+        when(wac.getMessage(eq("foo.bar"), eq(new Object[] { 1, 2 }), any(
+                Locale.class))).thenReturn("foo1 and bar2");
 
         when(wac.getServletContext()).thenReturn(sc);
         request = new MockHttpServletRequest(sc);
@@ -419,7 +419,8 @@ public class MessagesPanelTagTest {
     }
 
     /**
-     * Set default messages attribute name & Use ResultMessages & change PanelElement,OuterElement and InnerElement is empty.<br>
+     * Set default messages attribute name & Use ResultMessages & change PanelElement,OuterElement and InnerElement is
+     * empty.<br>
      * check JspTagException.
      */
     @Test(expected = JspTagException.class)

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
@@ -419,8 +419,7 @@ public class MessagesPanelTagTest {
     }
 
     /**
-     * Set default messages attribute name & Use ResultMessages & change PanelElement,OuterElement and InnerElement is
-     * empty.<br>
+     * Set default messages attribute name & Use ResultMessages & change PanelElement,OuterElement and InnerElement is empty.<br>
      * check JspTagException.
      */
     @Test(expected = JspTagException.class)

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -40,7 +40,6 @@ import org.springframework.mock.web.MockServletContext;
 import org.springframework.util.SerializationUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.tags.form.TagWriter;
-import org.terasoluna.gfw.web.pagination.PaginationTag;
 
 @SuppressWarnings("unchecked")
 public class PaginationTagTest {
@@ -411,8 +410,8 @@ public class PaginationTagTest {
         when(page.getSize()).thenReturn(10);
         when(page.getTotalPages()).thenReturn(100);
         when(page.getTotalElements()).thenReturn(1000L);
-        when(page.getSort()).thenReturn(
-                new Sort(new Sort.Order(Direction.DESC, "id")));
+        when(page.getSort()).thenReturn(Sort.by(
+                new Sort.Order(Direction.DESC, "id")));
 
         tag.setPage(page);
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
@@ -34,8 +34,7 @@ import org.terasoluna.gfw.web.util.HtmlEscapeUtils;
  * <ul>
  * <li>Escaping HTML tag using {@code f:h}</li>
  * <li>Encoding URL using {@code f:u}</li>
- * <li>Replacing new line characters with {@code <br />
- * } using {@code f:br}</li>
+ * <li>Replacing new line characters with {@code <br />} using {@code f:br}</li>
  * <li>Output only the specified characters {@code f:cut}</li>
  * <li>Output the link text in {@code <a>} tag using {@code f:link}</li>
  * <li>Build query string from the parameters using {@code f:query}</li>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
@@ -175,14 +175,7 @@ public final class Functions {
         if (value == null || value.isEmpty()) {
             return "";
         }
-        try {
-            return UriUtils.encodeQueryParam(value, "UTF-8");
-        } catch (UnsupportedEncodingException ignored) {
-            // This exception doesn't absolutely occur.
-            logger.warn("the given encoding parameter is not supported",
-                    ignored);
-            return value;
-        }
+        return UriUtils.encodeQueryParam(value, "UTF-8");
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
@@ -15,12 +15,9 @@
  */
 package org.terasoluna.gfw.web.el;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.core.convert.TypeDescriptor;
@@ -37,7 +34,8 @@ import org.terasoluna.gfw.web.util.HtmlEscapeUtils;
  * <ul>
  * <li>Escaping HTML tag using {@code f:h}</li>
  * <li>Encoding URL using {@code f:u}</li>
- * <li>Replacing new line characters with {@code <br />} using {@code f:br}</li>
+ * <li>Replacing new line characters with {@code <br />
+ * } using {@code f:br}</li>
  * <li>Output only the specified characters {@code f:cut}</li>
  * <li>Output the link text in {@code <a>} tag using {@code f:link}</li>
  * <li>Build query string from the parameters using {@code f:query}</li>
@@ -48,12 +46,6 @@ import org.terasoluna.gfw.web.util.HtmlEscapeUtils;
  * Refer JavaDoc of each method for information regarding how to use.<br>
  */
 public final class Functions {
-
-    /**
-     * logger
-     */
-    private static final Logger logger = LoggerFactory.getLogger(
-            Functions.class);
 
     /**
      * Pattern of URL for replace to the link tag.

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java
@@ -570,17 +570,16 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return ((LoggingEvent) argument).getFormattedMessage()
-                                .equals(expectedLogMessage);
+                    public boolean matches(LoggingEvent argument) {
+                        return argument.getFormattedMessage().equals(
+                                expectedLogMessage);
                     }
                 }));
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return expectedLogLevel.equals(((LoggingEvent) argument)
-                                .getLevel());
+                    public boolean matches(LoggingEvent argument) {
+                        return expectedLogLevel.equals(argument.getLevel());
                     }
                 }));
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java
@@ -317,7 +317,7 @@ public class FunctionsTest {
 
     @Test
     public void testU_EncodingDelimiter() {
-        assertThat(Functions.u("+"), is("%2B"));
+        assertThat(Functions.u("+"), is("+"));
         assertThat(Functions.u("="), is("%3D"));
         assertThat(Functions.u("&"), is("%26"));
     }
@@ -540,7 +540,7 @@ public class FunctionsTest {
         expectedQuery.append("&").append("key%5D3=value%5D3"); // ]
         expectedQuery.append("&").append("key%264=value%264"); // &
         expectedQuery.append("&").append("key%3D5=value%3D5"); // =
-        expectedQuery.append("&").append("key%2B6=value%2B6"); // +
+        expectedQuery.append("&").append("key+6=value+6"); // +
 
         assertThat(actualQuery, is(expectedQuery.toString()));
     }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java
@@ -542,17 +542,16 @@ public class HandlerExceptionResolverLoggingInterceptorTest {
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return ((LoggingEvent) argument).getFormattedMessage()
-                                .equals(expectedLogMessage);
+                    public boolean matches(LoggingEvent argument) {
+                        return argument.getFormattedMessage().equals(
+                                expectedLogMessage);
                     }
                 }));
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return expectedLogLevel.equals(((LoggingEvent) argument)
-                                .getLevel());
+                    public boolean matches(LoggingEvent argument) {
+                        return expectedLogLevel.equals(argument.getLevel());
                     }
                 }));
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java
@@ -279,17 +279,16 @@ public class HttpSessionEventLoggingListenerTest {
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return ((LoggingEvent) argument).getFormattedMessage()
-                                .equals(expectedLogMessage);
+                    public boolean matches(LoggingEvent argument) {
+                        return argument.getFormattedMessage().equals(
+                                expectedLogMessage);
                     }
                 }));
         verify(mockAppender).doAppend(argThat(
                 new ArgumentMatcher<LoggingEvent>() {
                     @Override
-                    public boolean matches(Object argument) {
-                        return expectedLogLevel.equals(((LoggingEvent) argument)
-                                .getLevel());
+                    public boolean matches(LoggingEvent argument) {
+                        return expectedLogLevel.equals(argument.getLevel());
                     }
                 }));
     }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java
@@ -18,8 +18,9 @@ package org.terasoluna.gfw.web.mvc.support;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +31,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 public class CompositeRequestDataValueProcessorTest {
@@ -52,12 +52,11 @@ public class CompositeRequestDataValueProcessorTest {
     @Test
     public void testProcessActionSameActionAndResult01() {
         // Set mock behavior
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString())).thenReturn(
-                        "action");
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString(), Mockito
-                        .isNull())).thenReturn("action");
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString())).thenReturn("action");
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString(), nullable(String.class)))
+                        .thenReturn("action");
         String result = compositeRequestDataValueProcessor.processAction(
                 request, "action");
         assertThat(result, is("action"));
@@ -66,12 +65,12 @@ public class CompositeRequestDataValueProcessorTest {
     @Test
     public void testProcessActionDifferectActionAndResult01() {
         // Set mock behavior
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString())).thenReturn(
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString())).thenReturn(
                         "other_action");
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString(), Mockito
-                        .isNull())).thenReturn("other_action");
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString(), nullable(String.class)))
+                        .thenReturn("other_action");
         String result = compositeRequestDataValueProcessor.processAction(
                 request, "action");
         assertThat(result, is("other_action"));
@@ -90,12 +89,11 @@ public class CompositeRequestDataValueProcessorTest {
     public void testProcessActionSameActionAndResult02() {
         // Set mock behavior
         // for Spring3
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString())).thenReturn(
-                        "action");
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString())).thenReturn("action");
         // for Spring4
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString(), anyString()))
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString(), anyString()))
                         .thenReturn("action");
         String result = compositeRequestDataValueProcessor.processAction(
                 request, "action", "method");
@@ -108,12 +106,12 @@ public class CompositeRequestDataValueProcessorTest {
     public void testProcessActionDifferectActionAndResult02() {
         // Set mock behavior
         // for Spring3
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString())).thenReturn(
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString())).thenReturn(
                         "other_action");
         // for Spring4
-        when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString(), anyString()))
+        when(requestDataValueProcessor.processAction(any(
+                HttpServletRequest.class), anyString(), anyString()))
                         .thenReturn("other_action");
         String result = compositeRequestDataValueProcessor.processAction(
                 request, "action", "method");
@@ -136,8 +134,8 @@ public class CompositeRequestDataValueProcessorTest {
     @Test
     public void testProcessFormFieldValueSameValueAndResult() {
         // Set Mock behavior
-        when(requestDataValueProcessor.processFormFieldValue(
-                (HttpServletRequest) (anyObject()), anyString(), anyString(),
+        when(requestDataValueProcessor.processFormFieldValue(any(
+                HttpServletRequest.class), anyString(), anyString(),
                 anyString())).thenReturn("value");
 
         String result = compositeRequestDataValueProcessor
@@ -148,8 +146,8 @@ public class CompositeRequestDataValueProcessorTest {
     @Test
     public void testProcessFormFieldValueDifferentValueAndResult() {
         // Set Mock behavior
-        when(requestDataValueProcessor.processFormFieldValue(
-                (HttpServletRequest) (anyObject()), anyString(), anyString(),
+        when(requestDataValueProcessor.processFormFieldValue(any(
+                HttpServletRequest.class), anyString(), anyString(),
                 anyString())).thenReturn("other_value");
 
         String result = compositeRequestDataValueProcessor
@@ -170,8 +168,8 @@ public class CompositeRequestDataValueProcessorTest {
     public void testGetExtraHiddenFieldsNullMapFromProcessorResult() {
 
         // Set Mock behavior
-        when(requestDataValueProcessor.getExtraHiddenFields(
-                (HttpServletRequest) (anyObject()))).thenReturn(null);
+        when(requestDataValueProcessor.getExtraHiddenFields(any(
+                HttpServletRequest.class))).thenReturn(null);
 
         Map<String, String> map = compositeRequestDataValueProcessor
                 .getExtraHiddenFields(request);
@@ -182,8 +180,8 @@ public class CompositeRequestDataValueProcessorTest {
     public void testGetExtraHiddenFieldsNotNullMapFromProcessorResult() {
 
         // Set Mock behavior
-        when(requestDataValueProcessor.getExtraHiddenFields(
-                (HttpServletRequest) (anyObject()))).thenReturn(
+        when(requestDataValueProcessor.getExtraHiddenFields(any(
+                HttpServletRequest.class))).thenReturn(
                         new HashMap<String, String>());
 
         Map<String, String> map = compositeRequestDataValueProcessor
@@ -204,9 +202,8 @@ public class CompositeRequestDataValueProcessorTest {
     public void testProcessUrlSameUrlAndResult() {
 
         // Set Mock behavior
-        when(requestDataValueProcessor.processUrl(
-                (HttpServletRequest) (anyObject()), anyString())).thenReturn(
-                        "http://localhost:8080/test");
+        when(requestDataValueProcessor.processUrl(any(HttpServletRequest.class),
+                anyString())).thenReturn("http://localhost:8080/test");
         String result = compositeRequestDataValueProcessor.processUrl(request,
                 "http://localhost:8080/test");
         assertThat(result, is("http://localhost:8080/test"));
@@ -216,9 +213,8 @@ public class CompositeRequestDataValueProcessorTest {
     public void testProcessUrlDifferentUrlAndResult() {
 
         // Set Mock behavior
-        when(requestDataValueProcessor.processUrl(
-                (HttpServletRequest) (anyObject()), anyString())).thenReturn(
-                        "http://localhost:9999/test");
+        when(requestDataValueProcessor.processUrl(any(HttpServletRequest.class),
+                anyString())).thenReturn("http://localhost:9999/test");
 
         String result = compositeRequestDataValueProcessor.processUrl(request,
                 "http://localhost:8080/test");

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java
@@ -18,8 +18,8 @@ package org.terasoluna.gfw.web.mvc.support;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 public class CompositeRequestDataValueProcessorTest {
@@ -51,14 +52,12 @@ public class CompositeRequestDataValueProcessorTest {
     @Test
     public void testProcessActionSameActionAndResult01() {
         // Set mock behavior
-        // for Spring3
         when(requestDataValueProcessor.processAction(
                 (HttpServletRequest) (anyObject()), anyString())).thenReturn(
                         "action");
-        // for Spring4
         when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString(), anyString()))
-                        .thenReturn("action");
+                (HttpServletRequest) (anyObject()), anyString(), Mockito
+                        .isNull())).thenReturn("action");
         String result = compositeRequestDataValueProcessor.processAction(
                 request, "action");
         assertThat(result, is("action"));
@@ -67,14 +66,12 @@ public class CompositeRequestDataValueProcessorTest {
     @Test
     public void testProcessActionDifferectActionAndResult01() {
         // Set mock behavior
-        // for Spring3
         when(requestDataValueProcessor.processAction(
                 (HttpServletRequest) (anyObject()), anyString())).thenReturn(
                         "other_action");
-        // for Spring4
         when(requestDataValueProcessor.processAction(
-                (HttpServletRequest) (anyObject()), anyString(), anyString()))
-                        .thenReturn("other_action");
+                (HttpServletRequest) (anyObject()), anyString(), Mockito
+                        .isNull())).thenReturn("other_action");
         String result = compositeRequestDataValueProcessor.processAction(
                 request, "action");
         assertThat(result, is("other_action"));

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationInfoTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationInfoTest.java
@@ -62,7 +62,7 @@ public class PaginationInfoTest {
         // 5(6 page) : 26-30
         // 6(7 page) : 31-35
         // ...
-        PageRequest pageable = new PageRequest(5, 5);
+        PageRequest pageable = PageRequest.of(5, 5);
 
         // set up the Page object for test.
         //
@@ -229,7 +229,7 @@ public class PaginationInfoTest {
     @Test
     public void testGetLastUrl() {
         List<String> mockedList = new ArrayList<String>();
-        PageRequest pageable = new PageRequest(2, 2);
+        PageRequest pageable = PageRequest.of(2, 2);
         page = new PageImpl<String>(mockedList, pageable, 4L);
 
         PaginationInfo info = new PaginationInfo(page, pathTmpl, queryTmpl, 0);
@@ -324,7 +324,7 @@ public class PaginationInfoTest {
     public void testIsLastPage_Last() {
         // parameter
         List<String> mockedList = new ArrayList<String>();
-        PageRequest pageable = new PageRequest(2, 2);
+        PageRequest pageable = PageRequest.of(2, 2);
         page = new PageImpl<String>(mockedList, pageable, 6L);
         PaginationInfo info = new PaginationInfo(page, pathTmpl, queryTmpl, 0);
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
@@ -15,16 +15,18 @@
  */
 package org.terasoluna.gfw.web.token.transaction;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.hamcrest.CoreMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Matchers.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -220,7 +222,7 @@ public class TransactionTokenInterceptorTest {
         TransactionTokenInfo tokenInfo = new TransactionTokenInfo("tokenName1", TransactionTokenType.IN);
 
         // Set mock behavior
-        when(tokenStore.getAndClear((TransactionToken) anyObject())).thenReturn(
+        when(tokenStore.getAndClear(any(TransactionToken.class))).thenReturn(
                 "differentValue");
 
         boolean result = interceptor.validateToken(inputToken, tokenStore,

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -392,7 +392,7 @@
     <!-- == TERASOLUNA == -->
     <terasoluna.gfw.version>5.5.0-SNAPSHOT</terasoluna.gfw.version>
     <!-- == Spring IO Platform == -->
-    <io.spring.platform.version>Brussels-SR5</io.spring.platform.version>
+    <io.spring.platform.version>Cairo-SR1</io.spring.platform.version>
     <!-- == MyBatis3 == -->
     <org.mybatis.version>3.4.5</org.mybatis.version>
     <org.mybatis.spring.version>1.3.1</org.mybatis.spring.version>
@@ -400,20 +400,20 @@
     <dozer.version>5.5.1</dozer.version>
     <!-- == Joda-Time == -->
     <joda-time.joda-time-jsptags.version>1.1.1</joda-time.joda-time-jsptags.version>
-    <jadira-usertype-core.version>5.0.0.GA</jadira-usertype-core.version>
+    <jadira-usertype-core.version>6.0.1.GA</jadira-usertype-core.version>
     <!-- == Logging == -->
     <org.lazyluke.version>0.2.7</org.lazyluke.version>
     <!-- == Project Properties == -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <archetype.test.skip>true</archetype.test.skip>
     <encoding>UTF-8</encoding>
-    <java-version>1.7</java-version>
+    <java-version>1.8</java-version>
     <!-- == Cargo Plugin == -->
     <cargo.jvmargs>-Xms512m -Xmx1024m</cargo.jvmargs>
     <cargo.daemon.url>http://localhost:18000</cargo.daemon.url>
-    <cargo.container.id>tomcat8x</cargo.container.id>
-    <cargo.container.url>http://archive.apache.org/dist/tomcat/tomcat-8/v${cargo.tomcat8.version}/bin/apache-tomcat-${cargo.tomcat8.version}.zip</cargo.container.url>
-    <cargo.tomcat8.version>8.5.20</cargo.tomcat8.version>
+    <cargo.container.id>tomcat9x</cargo.container.id>
+    <cargo.container.url>http://archive.apache.org/dist/tomcat/tomcat-9/v${cargo.tomcat9.version}/bin/apache-tomcat-${cargo.tomcat9.version}.zip</cargo.container.url>
+    <cargo.tomcat9.version>9.0.6</cargo.tomcat9.version>
   </properties>
   <profiles>
     <profile>

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -413,7 +413,7 @@
     <cargo.daemon.url>http://localhost:18000</cargo.daemon.url>
     <cargo.container.id>tomcat9x</cargo.container.id>
     <cargo.container.url>http://archive.apache.org/dist/tomcat/tomcat-9/v${cargo.tomcat9.version}/bin/apache-tomcat-${cargo.tomcat9.version}.zip</cargo.container.url>
-    <cargo.tomcat9.version>9.0.6</cargo.tomcat9.version>
+    <cargo.tomcat9.version>9.0.5</cargo.tomcat9.version>
   </properties>
   <profiles>
     <profile>


### PR DESCRIPTION
Please review #810
1. Change version to spring io platform Cairo-SR1
------------------------------------------------------

・terasoluna-gfw-parent/pom.xml 
<io.spring.platform.version> : Cairo-SR1
<jadira-usertype-core.version> : 6.0.1.GA
java-version : 1.8
<cargo.tomcat9.version> : 9.0.6

・terasoluna-gfw-common-libraries/pom.xml 
java-version : 1.8


2. Fix build error of UriUtils
------------------------------------------------------

・Error contents
[ERROR] /home/travis/build/terasolunaorg/terasoluna-gfw/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java:[180,11] exception java.io.UnsupportedEncodingException is never thrown in body of corresponding try statement

https://travis-ci.org/terasolunaorg/terasoluna-gfw/jobs/391071386#L2025

・Error occurrence location
https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java#L180

• Error cause
With Spring 5, UriUtils.encodeQueryParam has changed to not throw UnsupportedEncodingException.

https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/util/UriUtils.html#encodeQueryParam-java.lang.String-java.nio.charset.Charset-

· Correspondence to errors
Modify not to catch UnsupportedEncodingException.


3. Fix build error of Mockito
------------------------------------------------------

・Error contents
[ERROR] /home/travis/build/terasolunaorg/terasoluna-gfw/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java:[776,53] <anonymous org.terasoluna.gfw.common.exception.ExceptionLoggerTest$1> is not abstract and does not override abstract method matches(java.lang.Object) in org.mockito.ArgumentMatcher
https://travis-ci.org/terasolunaorg/terasoluna-gfw/jobs/391074725#L931

・Error occurrence location
https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ExceptionLoggerTest.java#L778

https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java#L573

https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java#L545

https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java#L282

• Error cause
This API was changed in Mockito 2.1.0 
matches(Object argument) -> matches(T argument)

https://static.javadoc.io/org.mockito/mockito-core/2.2.9/org/mockito/ArgumentMatcher.html

· Correspondence to errors
Modify as follows:
matches(Object argument)  -> matches(LoggingEvent argument) 


4. Fix failed tests of Mockito
------------------------------------------------------

・Error contents
CompositeRequestDataValueProcessorTest.testProcessActionSameActionAndResult01:64 
Expected: is "action"
     but: was null
  CompositeRequestDataValueProcessorTest.testProcessActionDifferectActionAndResult01:80 
Expected: is "other_action"
     but: was null

https://travis-ci.org/terasolunaorg/terasoluna-gfw/jobs/391107378#L1791

・Error occurrence location
https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessorTest.java#L60

• Error cause
Since Mockito 2.1.0, anyString() is only allow non-null String.
 
https://static.javadoc.io/org.mockito/mockito-core/2.18.3/org/mockito/ArgumentMatchers.html#anyString--

· Correspondence to errors
Depending on the source below, method parameter is fixed as "null".
anyString () -> Mockito.isNull ()

https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/CompositeRequestDataValueProcessor.java#L84


5. Fix failed tests of Spring
------------------------------------------------------

・Error contents
FunctionsTest.testU_EncodingDelimiter:320 
Expected: is "%2B"
     but: was "+"
  FunctionsTest.testQuery04_url_encoding_for_queryString:545 
Expected: is "key%231=value%231&key%5B2=value%5B2&key%5D3=value%5D3&key%264=value%264&key%3D5=value%3D5&key%2B6=value%2B6"
     but: was "key%231=value%231&key%5B2=value%5B2&key%5D3=value%5D3&key%264=value%264&key%3D5=value%3D5&key+6=value+6"

https://travis-ci.org/terasolunaorg/terasoluna-gfw/jobs/391107378#L1797

・Error occurrence location
https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java#L320

• Error cause
In Spring 4, +(0x2b) is encoding to %2B, But Since Spring 5, it does not encode to %2B.

https://jira.spring.io/browse/SPR-14828

· Correspondence to errors
Change %2B to +.


6. Fix build error of JDK7
------------------------------------------------------

・Error contents
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project terasoluna-gfw-common: Fatal error compiling: invalid target release: 1.8 

https://travis-ci.org/terasolunaorg/terasoluna-gfw/jobs/391551319#L830

・Error occurrence location
https://github.com/terasolunaorg/terasoluna-gfw/blob/5.5.0.RC2-development/.travis.yml#L6

• Error cause
Java 7 will not be supported from this term development version.

· Correspondence to errors
Delete openjdk7.
