### PR TITLE
Move dependency jackson-datatype-joda to gfw-jodatime-dependencies #736

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/pom.xml
@@ -66,12 +66,12 @@
       <artifactId>terasoluna-gfw-common</artifactId>
     </dependency>
 
-    <!-- == Begin Jackson == -->
+    <!-- == Begin Joda-Time == -->
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-joda</artifactId>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
     </dependency>
-    <!-- == End Jackson == -->
+    <!-- == End Joda-Time == -->
 
     <!-- Spring Test -->
     <dependency>

--- a/terasoluna-gfw-dependencies/terasoluna-gfw-jodatime-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/terasoluna-gfw-jodatime-dependencies/pom.xml
@@ -36,5 +36,11 @@
       <!-- this dependency does not pull servlet-api -->
     </dependency>
     <!-- == End Joda-Time == -->
+    <!-- == Begin Jackson == -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+    </dependency>
+    <!-- == End Jackson == -->
   </dependencies>
 </project>


### PR DESCRIPTION
Please review #736 .

fix as described in Issue.
After merging, do backport.