### PR TITLE
[5.4.x] Unify target of constraint annotations #857

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/ConsistOf.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/ConsistOf.java
@@ -15,7 +15,16 @@
  */
 package org.terasoluna.gfw.common.codepoints;
 
-import java.lang.annotation.*;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
@@ -26,9 +35,8 @@ import org.terasoluna.gfw.common.codepoints.validator.ConsistOfValidator;
  * All code points in the string must be included in any {@link CodePoints} class specified by {@link #value()}.
  * @since 5.1.0
  */
-@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE,
-        ElementType.PARAMETER })
-@Retention(RetentionPolicy.RUNTIME)
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
 @Constraint(validatedBy = { ConsistOfValidator.class })
 @Documented
 public @interface ConsistOf {
@@ -60,9 +68,8 @@ public @interface ConsistOf {
      * Defines several <code>@ConsistOf</code> annotations on the same element
      * @see ConsistOf
      */
-    @Target({ ElementType.METHOD, ElementType.FIELD,
-            ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
-    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+    @Retention(RUNTIME)
     @Documented
     @interface List {
         /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ExistInCodeList.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/ExistInCodeList.java
@@ -16,6 +16,7 @@
 package org.terasoluna.gfw.common.codelist;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -53,7 +54,7 @@ import org.terasoluna.gfw.common.codelist.validator.ExistInCodeListValidatorForC
  * returned with the default error message represented by {@code message()} in it.
  */
 @Documented
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, PARAMETER })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
 @Retention(RUNTIME)
 @Constraint(validatedBy = { ExistInCodeListValidatorForCharSequence.class,
         ExistInCodeListValidatorForCharacter.class,
@@ -88,7 +89,7 @@ public @interface ExistInCodeList {
      * Defines several <code>@ExistInCodeList</code> annotations on the same element
      * @see ExistInCodeList
      */
-    @Target({ METHOD, FIELD, ANNOTATION_TYPE, PARAMETER })
+    @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
     @Retention(RUNTIME)
     @Documented
     @interface List {


### PR DESCRIPTION
Please review #857 .

This PR is backport review of `@Target` and more(improvement and **Not** compliant with Bean Validation 2.0 from #863 ) to 5.4.x .
(5.4.x branch will **not** be compliant with Bean Validation 2.0)