### PR TITLE
[5.4.2.RELEASE]update tomcat version to 8.5.40 #896

### DIFF
--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -462,7 +462,7 @@
     <!-- == Tomcat == -->
     <!-- == Downgrade Tomcat from the Spring IO Platform as a Tomcat 8.5.39 bug. == -->
     <!-- == (https://github.com/spring-projects/spring-boot/issues/16486) == -->
-    <tomcat.version>8.5.38</tomcat.version>
+    <tomcat.version>8.5.40</tomcat.version>
     <!-- == Project Properties == -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <archetype.test.skip>true</archetype.test.skip>


### PR DESCRIPTION
Please review #896 .
Downgraded to `8.5.38` due to a [bug in tomcat 8.5.39](https://github.com/spring-projects/spring-boot/issues/16486), the above bug was resolved in 8.5.40.
https://github.com/spring-projects/spring-boot/issues/16504
Therefore, the version of tomcat is updated to `8.5.40`.