### PR TITLE
[5.5.x] Drop Oracle JDK from Travis CI #923

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
   - openjdk8
-  - oraclejdk11
   - openjdk11
 
 cache:


### PR DESCRIPTION
Please review #923 .
This PR is a backport.
Cherry picked from commit 41c6c945bdbfae80d1e908ff7caf39ec4e07e1b8 .