### PR TITLE
[5.4.x] Fix Travis CI environment for Trusty #923

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Please review #923 .
Added setting to use openjdk7.