### PR TITLE
fix sonarqube point out #971

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
@@ -47,9 +47,7 @@ public final class DateConvertUtils {
      * @throws IllegalArgumentException if the date is null
      */
     public static Timestamp convertToTimestamp(java.util.Date date) {
-        if (date == null) {
-            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
-        }
+        CheckDate(date);
         Timestamp timestamp = new Timestamp(date.getTime());
         return timestamp;
     }
@@ -64,9 +62,7 @@ public final class DateConvertUtils {
      * @throws IllegalArgumentException if the date is null
      */
     public static java.sql.Date convertToSqlDate(java.util.Date date) {
-        if (date == null) {
-            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
-        }
+        CheckDate(date);
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         cal.set(Calendar.HOUR_OF_DAY, 0);
@@ -87,9 +83,7 @@ public final class DateConvertUtils {
      * @throws IllegalArgumentException if the date is null
      */
     public static Time convertToTime(java.util.Date date) {
-        if (date == null) {
-            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
-        }
+        CheckDate(date);
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         cal.set(Calendar.YEAR, DEFAULT_YEAR);
@@ -97,5 +91,16 @@ public final class DateConvertUtils {
         cal.set(Calendar.DAY_OF_MONTH, 1);
         Time time = new Time(cal.getTimeInMillis());
         return time;
+    }
+
+    /**
+     * Check java.util.Date is not null<br>
+     * @param date check target
+     * @throws IllegalArgumentException if the date is null
+     */
+    private static void CheckDate(java.util.Date date) {
+        if (date == null) {
+            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
+        }
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
@@ -30,11 +30,6 @@ public final class DateConvertUtils {
     private static final int DEFAULT_YEAR = 1970;
 
     /**
-     * Message when argument is null.
-     */
-    private static final String MESSAGE_ARGUMENT_NULL_ERROR = "date must not be null";
-
-    /**
      * Default Constructor.
      */
     private DateConvertUtils() {
@@ -100,7 +95,7 @@ public final class DateConvertUtils {
      */
     private static void CheckDate(java.util.Date date) {
         if (date == null) {
-            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
+            throw new IllegalArgumentException("date must not be null");
         }
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
@@ -42,7 +42,7 @@ public final class DateConvertUtils {
      * @throws IllegalArgumentException if the date is null
      */
     public static Timestamp convertToTimestamp(java.util.Date date) {
-        CheckDate(date);
+        assertArgs(date);
         Timestamp timestamp = new Timestamp(date.getTime());
         return timestamp;
     }
@@ -57,7 +57,7 @@ public final class DateConvertUtils {
      * @throws IllegalArgumentException if the date is null
      */
     public static java.sql.Date convertToSqlDate(java.util.Date date) {
-        CheckDate(date);
+        assertArgs(date);
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         cal.set(Calendar.HOUR_OF_DAY, 0);
@@ -78,7 +78,7 @@ public final class DateConvertUtils {
      * @throws IllegalArgumentException if the date is null
      */
     public static Time convertToTime(java.util.Date date) {
-        CheckDate(date);
+        assertArgs(date);
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         cal.set(Calendar.YEAR, DEFAULT_YEAR);
@@ -89,11 +89,11 @@ public final class DateConvertUtils {
     }
 
     /**
-     * Check java.util.Date is not null<br>
-     * @param date check target
+     * Not null assertion on date<br>
+     * @param date assertion target
      * @throws IllegalArgumentException if the date is null
      */
-    private static void CheckDate(java.util.Date date) {
+    private static void assertArgs(java.util.Date date) {
         if (date == null) {
             throw new IllegalArgumentException("date must not be null");
         }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/DateConvertUtils.java
@@ -30,6 +30,11 @@ public final class DateConvertUtils {
     private static final int DEFAULT_YEAR = 1970;
 
     /**
+     * Message when argument is null.
+     */
+    private static final String MESSAGE_ARGUMENT_NULL_ERROR = "date must not be null";
+
+    /**
      * Default Constructor.
      */
     private DateConvertUtils() {
@@ -43,7 +48,7 @@ public final class DateConvertUtils {
      */
     public static Timestamp convertToTimestamp(java.util.Date date) {
         if (date == null) {
-            throw new IllegalArgumentException("date must not be null");
+            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
         }
         Timestamp timestamp = new Timestamp(date.getTime());
         return timestamp;
@@ -60,7 +65,7 @@ public final class DateConvertUtils {
      */
     public static java.sql.Date convertToSqlDate(java.util.Date date) {
         if (date == null) {
-            throw new IllegalArgumentException("date must not be null");
+            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
         }
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);
@@ -83,7 +88,7 @@ public final class DateConvertUtils {
      */
     public static Time convertToTime(java.util.Date date) {
         if (date == null) {
-            throw new IllegalArgumentException("date must not be null");
+            throw new IllegalArgumentException(MESSAGE_ARGUMENT_NULL_ERROR);
         }
         Calendar cal = Calendar.getInstance();
         cal.setTime(date);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import static org.springframework.test.util.ReflectionTestUtils.getField;
-
 import java.io.StringWriter;
 import java.util.regex.Pattern;
 
@@ -41,6 +39,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockPageContext;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.SerializationUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.tags.form.TagWriter;
@@ -89,24 +88,25 @@ public class PaginationTagTest {
 
         tag.release();
 
-        assertNull(getField(tag, "page"));
-        assertNull(getField(tag, "pathTmpl"));
-        assertNull(getField(tag, "queryTmpl"));
-        assertNull(getField(tag, "criteriaQuery"));
-        assertFalse((boolean) getField(tag,
+        assertNull(ReflectionTestUtils.getField(tag, "page"));
+        assertNull(ReflectionTestUtils.getField(tag, "pathTmpl"));
+        assertNull(ReflectionTestUtils.getField(tag, "queryTmpl"));
+        assertNull(ReflectionTestUtils.getField(tag, "criteriaQuery"));
+        assertFalse((boolean) ReflectionTestUtils.getField(tag,
                 "disableHtmlEscapeOfCriteriaQuery"));
-        assertFalse((boolean) getField(tag, "enableLinkOfCurrentPage"));
-        assertNull(getField(tag, "outerElement"));
-        assertNull(getField(tag, "outerElementClass"));
-        assertNull(getField(tag, "innerElement"));
-        assertNull(getField(tag, "innerElementClass"));
-        assertNull(getField(tag, "firstLinkText"));
-        assertNull(getField(tag, "previousLinkText"));
-        assertNull(getField(tag, "nextLinkText"));
-        assertNull(getField(tag, "lastLinkText"));
-        assertNull(getField(tag, "disabledHref"));
-        assertNull(getField(tag, "activeClass"));
-        assertNull(getField(tag, "disabledClass"));
+        assertFalse((boolean) ReflectionTestUtils.getField(tag,
+                "enableLinkOfCurrentPage"));
+        assertNull(ReflectionTestUtils.getField(tag, "outerElement"));
+        assertNull(ReflectionTestUtils.getField(tag, "outerElementClass"));
+        assertNull(ReflectionTestUtils.getField(tag, "innerElement"));
+        assertNull(ReflectionTestUtils.getField(tag, "innerElementClass"));
+        assertNull(ReflectionTestUtils.getField(tag, "firstLinkText"));
+        assertNull(ReflectionTestUtils.getField(tag, "previousLinkText"));
+        assertNull(ReflectionTestUtils.getField(tag, "nextLinkText"));
+        assertNull(ReflectionTestUtils.getField(tag, "lastLinkText"));
+        assertNull(ReflectionTestUtils.getField(tag, "disabledHref"));
+        assertNull(ReflectionTestUtils.getField(tag, "activeClass"));
+        assertNull(ReflectionTestUtils.getField(tag, "disabledClass"));
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -23,8 +23,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+
 import java.io.StringWriter;
-import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 
 import javax.servlet.jsp.tagext.TagSupport;
@@ -40,7 +41,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockPageContext;
 import org.springframework.mock.web.MockServletContext;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.util.SerializationUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.tags.form.TagWriter;
@@ -89,74 +89,24 @@ public class PaginationTagTest {
 
         tag.release();
 
-        Field page = ReflectionUtils.findField(PaginationTag.class, "page");
-        ReflectionUtils.makeAccessible(page);
-        Field pathTmpl = ReflectionUtils.findField(PaginationTag.class,
-                "pathTmpl");
-        ReflectionUtils.makeAccessible(pathTmpl);
-        Field queryTmpl = ReflectionUtils.findField(PaginationTag.class,
-                "queryTmpl");
-        ReflectionUtils.makeAccessible(queryTmpl);
-        Field criteriaQuery = ReflectionUtils.findField(PaginationTag.class,
-                "criteriaQuery");
-        ReflectionUtils.makeAccessible(criteriaQuery);
-        Field disableHtmlEscapeOfCriteriaQuery = ReflectionUtils.findField(
-                PaginationTag.class, "disableHtmlEscapeOfCriteriaQuery");
-        ReflectionUtils.makeAccessible(disableHtmlEscapeOfCriteriaQuery);
-        Field enableLinkOfCurrentPage = ReflectionUtils.findField(
-                PaginationTag.class, "enableLinkOfCurrentPage");
-        ReflectionUtils.makeAccessible(enableLinkOfCurrentPage);
-        Field outerElement = ReflectionUtils.findField(PaginationTag.class,
-                "outerElement");
-        ReflectionUtils.makeAccessible(outerElement);
-        Field outerElementClass = ReflectionUtils.findField(PaginationTag.class,
-                "outerElementClass");
-        ReflectionUtils.makeAccessible(outerElementClass);
-        Field innerElement = ReflectionUtils.findField(PaginationTag.class,
-                "innerElement");
-        ReflectionUtils.makeAccessible(innerElement);
-        Field innerElementClass = ReflectionUtils.findField(PaginationTag.class,
-                "innerElementClass");
-        ReflectionUtils.makeAccessible(innerElementClass);
-        Field firstLinkText = ReflectionUtils.findField(PaginationTag.class,
-                "firstLinkText");
-        ReflectionUtils.makeAccessible(firstLinkText);
-        Field previousLinkText = ReflectionUtils.findField(PaginationTag.class,
-                "previousLinkText");
-        ReflectionUtils.makeAccessible(previousLinkText);
-        Field nextLinkText = ReflectionUtils.findField(PaginationTag.class,
-                "nextLinkText");
-        ReflectionUtils.makeAccessible(nextLinkText);
-        Field lastLinkText = ReflectionUtils.findField(PaginationTag.class,
-                "lastLinkText");
-        ReflectionUtils.makeAccessible(lastLinkText);
-        Field disabledHref = ReflectionUtils.findField(PaginationTag.class,
-                "disabledHref");
-        ReflectionUtils.makeAccessible(disabledHref);
-        Field activeClass = ReflectionUtils.findField(PaginationTag.class,
-                "activeClass");
-        ReflectionUtils.makeAccessible(activeClass);
-        Field disabledClass = ReflectionUtils.findField(PaginationTag.class,
-                "disabledClass");
-        ReflectionUtils.makeAccessible(disabledClass);
-
-        assertNull(page.get(tag));
-        assertNull(pathTmpl.get(tag));
-        assertNull(queryTmpl.get(tag));
-        assertNull(criteriaQuery.get(tag));
-        assertFalse((boolean) disableHtmlEscapeOfCriteriaQuery.get(tag));
-        assertFalse((boolean) enableLinkOfCurrentPage.get(tag));
-        assertNull(outerElement.get(tag));
-        assertNull(outerElementClass.get(tag));
-        assertNull(innerElement.get(tag));
-        assertNull(innerElementClass.get(tag));
-        assertNull(firstLinkText.get(tag));
-        assertNull(previousLinkText.get(tag));
-        assertNull(nextLinkText.get(tag));
-        assertNull(lastLinkText.get(tag));
-        assertNull(disabledHref.get(tag));
-        assertNull(activeClass.get(tag));
-        assertNull(disabledClass.get(tag));
+        assertNull(getField(tag, "page"));
+        assertNull(getField(tag, "pathTmpl"));
+        assertNull(getField(tag, "queryTmpl"));
+        assertNull(getField(tag, "criteriaQuery"));
+        assertFalse((boolean) getField(tag,
+                "disableHtmlEscapeOfCriteriaQuery"));
+        assertFalse((boolean) getField(tag, "enableLinkOfCurrentPage"));
+        assertNull(getField(tag, "outerElement"));
+        assertNull(getField(tag, "outerElementClass"));
+        assertNull(getField(tag, "innerElement"));
+        assertNull(getField(tag, "innerElementClass"));
+        assertNull(getField(tag, "firstLinkText"));
+        assertNull(getField(tag, "previousLinkText"));
+        assertNull(getField(tag, "nextLinkText"));
+        assertNull(getField(tag, "lastLinkText"));
+        assertNull(getField(tag, "disabledHref"));
+        assertNull(getField(tag, "activeClass"));
+        assertNull(getField(tag, "disabledClass"));
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -16,12 +16,15 @@
 package org.terasoluna.gfw.web.pagination;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.StringWriter;
+import java.lang.reflect.Field;
 import java.util.regex.Pattern;
 
 import javax.servlet.jsp.tagext.TagSupport;
@@ -37,6 +40,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockPageContext;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.SerializationUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.tags.form.TagWriter;
@@ -82,7 +86,77 @@ public class PaginationTagTest {
 
     @Test
     public void testRelease01() throws Exception {
+
         tag.release();
+
+        Field page = ReflectionUtils.findField(PaginationTag.class, "page");
+        ReflectionUtils.makeAccessible(page);
+        Field pathTmpl = ReflectionUtils.findField(PaginationTag.class,
+                "pathTmpl");
+        ReflectionUtils.makeAccessible(pathTmpl);
+        Field queryTmpl = ReflectionUtils.findField(PaginationTag.class,
+                "queryTmpl");
+        ReflectionUtils.makeAccessible(queryTmpl);
+        Field criteriaQuery = ReflectionUtils.findField(PaginationTag.class,
+                "criteriaQuery");
+        ReflectionUtils.makeAccessible(criteriaQuery);
+        Field disableHtmlEscapeOfCriteriaQuery = ReflectionUtils.findField(
+                PaginationTag.class, "disableHtmlEscapeOfCriteriaQuery");
+        ReflectionUtils.makeAccessible(disableHtmlEscapeOfCriteriaQuery);
+        Field enableLinkOfCurrentPage = ReflectionUtils.findField(
+                PaginationTag.class, "enableLinkOfCurrentPage");
+        ReflectionUtils.makeAccessible(enableLinkOfCurrentPage);
+        Field outerElement = ReflectionUtils.findField(PaginationTag.class,
+                "outerElement");
+        ReflectionUtils.makeAccessible(outerElement);
+        Field outerElementClass = ReflectionUtils.findField(PaginationTag.class,
+                "outerElementClass");
+        ReflectionUtils.makeAccessible(outerElementClass);
+        Field innerElement = ReflectionUtils.findField(PaginationTag.class,
+                "innerElement");
+        ReflectionUtils.makeAccessible(innerElement);
+        Field innerElementClass = ReflectionUtils.findField(PaginationTag.class,
+                "innerElementClass");
+        ReflectionUtils.makeAccessible(innerElementClass);
+        Field firstLinkText = ReflectionUtils.findField(PaginationTag.class,
+                "firstLinkText");
+        ReflectionUtils.makeAccessible(firstLinkText);
+        Field previousLinkText = ReflectionUtils.findField(PaginationTag.class,
+                "previousLinkText");
+        ReflectionUtils.makeAccessible(previousLinkText);
+        Field nextLinkText = ReflectionUtils.findField(PaginationTag.class,
+                "nextLinkText");
+        ReflectionUtils.makeAccessible(nextLinkText);
+        Field lastLinkText = ReflectionUtils.findField(PaginationTag.class,
+                "lastLinkText");
+        ReflectionUtils.makeAccessible(lastLinkText);
+        Field disabledHref = ReflectionUtils.findField(PaginationTag.class,
+                "disabledHref");
+        ReflectionUtils.makeAccessible(disabledHref);
+        Field activeClass = ReflectionUtils.findField(PaginationTag.class,
+                "activeClass");
+        ReflectionUtils.makeAccessible(activeClass);
+        Field disabledClass = ReflectionUtils.findField(PaginationTag.class,
+                "disabledClass");
+        ReflectionUtils.makeAccessible(disabledClass);
+
+        assertNull(page.get(tag));
+        assertNull(pathTmpl.get(tag));
+        assertNull(queryTmpl.get(tag));
+        assertNull(criteriaQuery.get(tag));
+        assertFalse((boolean) disableHtmlEscapeOfCriteriaQuery.get(tag));
+        assertFalse((boolean) enableLinkOfCurrentPage.get(tag));
+        assertNull(outerElement.get(tag));
+        assertNull(outerElementClass.get(tag));
+        assertNull(innerElement.get(tag));
+        assertNull(innerElementClass.get(tag));
+        assertNull(firstLinkText.get(tag));
+        assertNull(previousLinkText.get(tag));
+        assertNull(nextLinkText.get(tag));
+        assertNull(lastLinkText.get(tag));
+        assertNull(disabledHref.get(tag));
+        assertNull(activeClass.get(tag));
+        assertNull(disabledClass.get(tag));
     }
 
     /**
@@ -945,34 +1019,6 @@ public class PaginationTagTest {
         // That the and-mark(&) is remove
         assertThat(getOutput(), is(expected.toString()));
     }
-
-    @Test
-    public void testDoStartTagInternal_disabledHref_and_firstLinkText_are_empty() throws Exception {
-    }
-
-    // @Test
-    // public void testWriteAnchor01() throws Exception {
-    // }
-    //
-    // @Test
-    // public void testStartOuterElement01() throws Exception {
-    // }
-    //
-    // @Test
-    // public void testEndOuterElement01() throws Exception {
-    // }
-    //
-    // @Test
-    // public void testWritePageLink01() throws Exception {
-    // }
-    //
-    // @Test
-    // public void testWriteFirstAndPreviousLink01() throws Exception {
-    // }
-    //
-    // @Test
-    // public void testWriteNextAndLastLink01() throws Exception {
-    // }
 
     @Test
     public void testSetters() {


### PR DESCRIPTION
Please review #971.

3 out of 9 cases were modified.

-----
Modified

* `PaginationTagTest`
→ Test assertion added (Check for null and false after [release()](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java#L384) method execution)

* `PaginationTagTest`
→ Delete empty test (What has not changed since the [first commit](https://github.com/terasolunaorg/terasoluna-gfw/blob/2b360b3849adf4b4b11cb42ae2775c41a6184f3a/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java#L599))

* `DateConvertUtils`
→ Eliminate duplicate strings.

-----
As it is

* `PaginationTag`
→ Regarding the complexity of [writeFirstAndPreviousLink](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java#L256
), I keep it because I couldn't find a valid refactoring method.
([This unit](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java#L261-L269) when separating, but it is necessary to create a method for each and it is judged that it is not effective)

* `PaginationTag`
→ For the complexity of [writeNextAndLastLink](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java#L320), made the same decision as `writeFirstAndPreviousLink`.

* `ObjectToMapConverter`
→ Regarding the complexity of [flatten](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/ObjectToMapConverter.java#L284), I keep it because I couldn't find a valid refactoring method. 
(I think this is inseparable)

* `AbstractExistInCodeListValidator`
→ Regarding the problem that the [variable name](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/validator/AbstractExistInCodeListValidator.java#L41) overlaps with the [super class](https://github.com/spring-projects/spring-framework/blob/v5.2.3.RELEASE/spring-context/src/main/java/org/springframework/context/support/ApplicationObjectSupport.java#L52), it is judged that there is no problem because the logger class used is different (not used `org.apache.commons.logging.Log` of the super class, use `org.slf4j.Logger` )

* `AbstractFileDownloadView`
→ Make the same decision as `AbstractExistInCodeListValidator`  for [variable names](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java#L87) that overlap with the [superclass](https://github.com/spring-projects/spring-framework/blob/v5.2.3.RELEASE/spring-context/src/main/java/org/springframework/context/support/ApplicationObjectSupport.java#L52).

* `TransactionTokenInterceptor`
→ The problem of returning the same return value in [preHandle](https://github.com/terasolunaorg/terasoluna-gfw/blob/f88f52b1e64be9ed19ce14299b8da400a4bb7bd7/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptor.java#L145) was determined to be no problem from the method specification. (I referenced the Javadoc)
