### PR TITLE
exclude hibernate-entitymanager from jadira usertype.core #984

### DIFF
--- a/terasoluna-gfw-dependencies/terasoluna-gfw-jpa-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/terasoluna-gfw-jpa-dependencies/pom.xml
@@ -43,6 +43,12 @@
     <dependency>
       <groupId>org.jadira.usertype</groupId>
       <artifactId>usertype.core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-entitymanager</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- == End Joda-Time == -->
     <!-- == End JPA == -->


### PR DESCRIPTION
Please review #984 .

Grep with `mvn dependency: tree` and confirmed that there is no omission in exclusion.