### PR TITLE
separete tests for different locales #996

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorJaTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorJaTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright(c) 2013 NTT DATA Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.terasoluna.gfw.common.codepoints.validator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Locale;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.junit.Test;
+
+public class ConsistOfValidatorJaTest {
+
+    public ConsistOfValidatorJaTest() {
+        Locale.setDefault(Locale.JAPANESE);
+    }
+
+    @Test
+    public void testIsValid_message_japanese() throws Exception {
+        Name_Simple name = new Name_Simple("abc", "GHI");
+        Validator validator = Validation.buildDefaultValidatorFactory()
+                .getValidator();
+        Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
+                name);
+
+        assertThat(violations, is(notNullValue()));
+        assertThat(violations.size(), is(1));
+
+        ConstraintViolation<Name_Simple> v = violations.iterator().next();
+        assertThat(v.getPropertyPath().toString(), is("firstName"));
+        assertThat(v.getMessage(), is("指定されたコードポイントで構成されていません"));
+    }
+
+}

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
@@ -413,22 +413,4 @@ public class ConsistOfValidatorTest {
 
     }
 
-    @Test
-    public void testIsValid_message_japanese() throws Exception {
-        Locale.setDefault(Locale.JAPANESE);
-        Name_Simple name = new Name_Simple("abc", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
-                name);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Simple> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("firstName"));
-        assertThat(v.getMessage(), is("指定されたコードポイントで構成されていません"));
-        Locale.setDefault(Locale.ENGLISH);
-    }
-
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListJaTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListJaTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright(c) 2013 NTT DATA Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.terasoluna.gfw.common.codelist;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Locale;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("ExistInCodeListTest-context.xml")
+public class ExistInCodeListJaTest {
+
+    @Inject
+    Validator validator;
+
+    public ExistInCodeListJaTest() {
+        Locale.setDefault(Locale.JAPANESE);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_messageJapanese() {
+        Customer c = new Customer();
+        c.gender = 'G';
+        c.lang = "JP";
+        Set<ConstraintViolation<Customer>> result = validator.validate(c);
+        assertThat(result.size(), is(1));
+        assertThat(((ConstraintViolation<Customer>) result.toArray()[0])
+                .getMessage(), is("CD_GENDER にありません"));
+    }
+
+    private class Customer {
+        @ExistInCodeList(codeListId = "CD_GENDER")
+        public Character gender;
+
+        @ExistInCodeList(codeListId = "CD_LANG")
+        public String lang;
+    }
+}

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListTest.java
@@ -424,20 +424,6 @@ public class ExistInCodeListTest {
         assertThat(violations.size(), is(2));
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void test_messageJapanese() {
-        Locale.setDefault(Locale.JAPANESE);
-        Customer c = new Customer();
-        c.gender = 'G';
-        c.lang = "JP";
-        Set<ConstraintViolation<Customer>> result = validator.validate(c);
-        assertThat(result.size(), is(1));
-        assertThat(((ConstraintViolation<Customer>) result.toArray()[0])
-                .getMessage(), is("CD_GENDER にありません"));
-        Locale.setDefault(Locale.ENGLISH);
-    }
-
     @Validated
     public interface CodeService {
         String getGenderLabel(


### PR DESCRIPTION
Please review #996.

In #1001, the test for Japanese was implemented in the existing test class. It was found that if the locale was changed for each test in 1 class, the locale would be changed at an unintended timing depending on the runtime environment. So I separated tests for different locales as a workaround.