### PR TITLE
resolve spring 5.3.0 deprecated StringUtils#isEmpty #1015

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/DefaultExceptionLevelResolver.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/DefaultExceptionLevelResolver.java
@@ -15,6 +15,8 @@
  */
 package org.terasoluna.gfw.common.exception;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Default class for resolving exception level
  */
@@ -66,7 +68,7 @@ public class DefaultExceptionLevelResolver implements ExceptionLevelResolver {
     @Override
     public ExceptionLevel resolveExceptionLevel(Exception ex) {
         String exceptionCode = resolveExceptionCode(ex);
-        if (exceptionCode == null || exceptionCode.isEmpty()) {
+        if (!StringUtils.hasText(exceptionCode)) {
             return ExceptionLevel.ERROR;
         }
         String exceptionCodePrefix = exceptionCode.substring(0, 1);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLogger.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/ExceptionLogger.java
@@ -380,10 +380,10 @@ public class ExceptionLogger implements InitializingBean {
 
         String bindingExceptionCode = exceptionCode;
         String bindingExceptionMessage = exceptionMessage;
-        if (StringUtils.isEmpty(bindingExceptionCode)) {
+        if (!StringUtils.hasText(bindingExceptionCode)) {
             bindingExceptionCode = defaultCode;
         }
-        if (StringUtils.isEmpty(bindingExceptionMessage)) {
+        if (!StringUtils.hasText(bindingExceptionMessage)) {
             bindingExceptionMessage = defaultMessage;
         }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/SimpleMappingExceptionCodeResolver.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/SimpleMappingExceptionCodeResolver.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Class for resolving exception code.
@@ -112,7 +113,7 @@ public class SimpleMappingExceptionCodeResolver implements
             }
         }
 
-        if (exceptionMappings == null || exceptionMappings.isEmpty()) {
+        if (CollectionUtils.isEmpty(exceptionMappings)) {
             return defaultExceptionCode;
         }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/MessagesPanelTag.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/MessagesPanelTag.java
@@ -292,7 +292,7 @@ public class MessagesPanelTag extends RequestContextAwareTag {
             String type) {
         if (panelTypeClassPrefix != null && StringUtils.hasText(type)) {
 
-            if (StringUtils.hasLength(className)) {
+            if (StringUtils.hasText(className)) {
                 className.append(" ");
             }
             className.append(panelTypeClassPrefix);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
@@ -23,6 +23,8 @@ import org.springframework.beans.BeanWrapper;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.format.support.FormattingConversionService;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
 import org.terasoluna.gfw.web.util.HtmlEscapeUtils;
@@ -168,7 +170,7 @@ public final class Functions {
      * @see <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986 3.4.Query</a>
      */
     public static String u(String value) {
-        if (value == null || value.isEmpty()) {
+        if (!StringUtils.hasLength(value)) {
             return "";
         }
         return extraEncodeQuery(UriUtils.encodeQueryParam(value, "UTF-8"));
@@ -180,7 +182,7 @@ public final class Functions {
      * @return converted string. returns empty string if <code>value</code> is <code>null</code> or empty.
      */
     public static String br(String value) {
-        if (value == null || value.isEmpty()) {
+        if (!StringUtils.hasLength(value)) {
             return "";
         }
         String replacedValue = LINE_BREAK_PATTERN.matcher(value).replaceAll(
@@ -195,7 +197,7 @@ public final class Functions {
      * @return cut string. returns empty string if <code>value</code> is <code>null</code> or empty.
      */
     public static String cut(String value, int length) {
-        if (value == null || value.isEmpty()) {
+        if (!StringUtils.hasLength(value)) {
             return "";
         }
         StringBuilder sb = new StringBuilder();
@@ -214,7 +216,7 @@ public final class Functions {
      * @return converted string. returns empty string if <code>value</code> is <code>null</code> or empty.
      */
     public static String link(String value) {
-        if (value == null || value.isEmpty()) {
+        if (!StringUtils.hasLength(value)) {
             return "";
         }
         return URL_PATTERN.matcher(value).replaceAll("<a href=\"$0\">$0</a>");
@@ -230,7 +232,7 @@ public final class Functions {
      * @return query string. if map is not empty, return query string. ex) name1=value&amp;name2=value&amp;...
      */
     public static String mapToQuery(Map<String, ?> map) {
-        if (map == null || map.isEmpty()) {
+        if (CollectionUtils.isEmpty(map)) {
             return "";
         }
         UriComponentsBuilder builder = UriComponentsBuilder.fromPath("");
@@ -259,7 +261,7 @@ public final class Functions {
     @Deprecated
     public static String mapToQuery(Map<String, ?> map,
             BeanWrapper beanWrapper) {
-        if (map == null || map.isEmpty()) {
+        if (CollectionUtils.isEmpty(map)) {
             return "";
         }
         UriComponentsBuilder builder = UriComponentsBuilder.fromPath("");
@@ -340,7 +342,7 @@ public final class Functions {
      * @return escaped string. returns empty string if <code>value</code> is <code>null</code> or empty.
      */
     public static String js(String value) {
-        if (value == null || value.isEmpty()) {
+        if (!StringUtils.hasLength(value)) {
             return "";
         }
         StringBuilder result = new StringBuilder();

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/ObjectToMapConverter.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/ObjectToMapConverter.java
@@ -170,11 +170,11 @@ class ObjectToMapConverter {
     private Map<String, String> convert(String prefix, Map<?, ?> value) {
         Map<String, String> map = new LinkedHashMap<String, String>();
         for (Map.Entry<?, ?> e : value.entrySet()) {
-            if (StringUtils.isEmpty(prefix)) {
-                map.putAll(this.convert(e.getKey().toString(), e.getValue()));
-            } else {
+            if (StringUtils.hasText(prefix)) {
                 map.putAll(this.convert(prefix + "[" + e.getKey() + "]", e
                         .getValue()));
+            } else {
+                map.putAll(this.convert(e.getKey().toString(), e.getValue()));
             }
         }
         return map;
@@ -288,7 +288,7 @@ class ObjectToMapConverter {
      */
     private boolean flatten(Map<String, String> map, String prefix, String name,
             Object value, TypeDescriptor sourceType) {
-        String key = StringUtils.isEmpty(prefix) ? name : prefix + "." + name;
+        String key = StringUtils.hasText(prefix) ? prefix + "." + name : name;
         if (value == null) {
             String resetKey = determineResetKey(key, sourceType);
             map.put(resetKey, "");
@@ -297,14 +297,14 @@ class ObjectToMapConverter {
         }
         Class<?> clazz = value.getClass();
         if (value instanceof Iterable) {
-            if (StringUtils.isEmpty(name)) {
+            if (!StringUtils.hasText(name)) {
                 // skip flatten
                 return true;
             }
             Iterable<?> iterable = (Iterable<?>) value;
             map.putAll(this.convert(key, iterable));
         } else if (clazz.isArray()) {
-            if (StringUtils.isEmpty(name)) {
+            if (!StringUtils.hasText(name)) {
                 // skip flatten
                 return true;
             }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/PaginationInfo.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/PaginationInfo.java
@@ -267,7 +267,7 @@ public class PaginationInfo {
      * @since 1.0.1
      */
     private String removeHeadDelimiterOfQueryString(String queryString) {
-        if (!StringUtils.hasLength(queryString)) {
+        if (!StringUtils.hasText(queryString)) {
             return queryString;
         }
         if (queryString.startsWith("?") || queryString.startsWith("&")) {
@@ -366,7 +366,7 @@ public class PaginationInfo {
                 page.getSort());
         StringBuilder pageUriBuilder = new StringBuilder(pageUri.expand(attr)
                 .encode().toUriString());
-        if (StringUtils.hasLength(criteriaQuery)) {
+        if (StringUtils.hasText(criteriaQuery)) {
             if (pageUri.getQueryParams().isEmpty()) {
                 pageUriBuilder.append("?");
             } else {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionToken.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionToken.java
@@ -17,6 +17,8 @@ package org.terasoluna.gfw.web.token.transaction;
 
 import java.io.Serializable;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Class representing the transaction token string
  */
@@ -58,7 +60,7 @@ public class TransactionToken implements Serializable {
         String tokenNameTmp = "";
         String tokenKeyTmp = "";
         String tokenValueTmp = "";
-        if (tokenString != null && !tokenString.isEmpty()) {
+        if (StringUtils.hasText(tokenString)) {
             String[] strs = tokenString.split(TOKEN_STRING_SEPARATOR);
             if (strs.length == 3) {
                 tokenNameTmp = strs[0];
@@ -117,13 +119,13 @@ public class TransactionToken implements Serializable {
      * @return if all values are present, return <code>true</code>
      */
     public boolean valid() {
-        if (tokenKey == null || tokenKey.isEmpty()) {
+        if (!StringUtils.hasText(tokenKey)) {
             return false;
         }
-        if (tokenValue == null || tokenValue.isEmpty()) {
+        if (!StringUtils.hasText(tokenValue)) {
             return false;
         }
-        if (tokenName == null || tokenName.isEmpty()) {
+        if (!StringUtils.hasText(tokenName)) {
             return false;
         }
         return true;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoStore.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInfoStore.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.method.HandlerMethod;
 
 /**
@@ -109,10 +110,10 @@ public class TransactionTokenInfoStore {
                 : classAnnotation.value();
 
         StringBuilder tokenNameStringBuilder = new StringBuilder();
-        if (classTokenName != null && !classTokenName.isEmpty()) {
+        if (StringUtils.hasText(classTokenName)) {
             tokenNameStringBuilder.append(classTokenName);
         }
-        if (methodTokenName != null && !methodTokenName.isEmpty()) {
+        if (StringUtils.hasText(methodTokenName)) {
             if (tokenNameStringBuilder.length() != 0) {
                 tokenNameStringBuilder.append("/");
             }


### PR DESCRIPTION
Please review #1015 .

#### Changes summary
* all of `StringUtils#isEmpty` -> `StringUtils#hasLength` or `StringUtils#hasText`
* a part of `str == null || str.isEmpty()` ->`StringUtils#hasLength` or `StringUtils#hasText`
  - These depend on Spring Core but make their own decisions.
* a part of `collection == null || collection.isEmpty()` ->`CollectionUtils#isEmpty` or `StringUtils#hasText`
  - These depend on Spring Core but make their own decisions.
* a part of `StringUtils#hasLength` -> `StringUtils#hasText`
  - These don't make sense to handle whitespace.
