### PR TITLE
improve assertions #1017

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/CodePointsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/CodePointsTest.java
@@ -18,11 +18,12 @@ package org.terasoluna.gfw.common.codepoints;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -569,7 +570,7 @@ public class CodePointsTest {
         Set<Integer> result = new CodePoints(allowedCodePointSet)
                 .allExcludedCodePoints(testStr);
 
-        assertThat(result.size(), is(0));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -580,7 +581,7 @@ public class CodePointsTest {
         Set<Integer> result = new CodePoints(allowedCodePointSet)
                 .allExcludedCodePoints(testStr);
 
-        assertThat(result.size(), is(0));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -598,7 +599,7 @@ public class CodePointsTest {
         Set<Integer> result = new CodePoints(allowedCodePointSet)
                 .allExcludedCodePoints(testStr);
 
-        assertThat(result.size(), is(0));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -615,8 +616,7 @@ public class CodePointsTest {
         Set<Integer> result = new CodePoints(allowedCodePointSet)
                 .allExcludedCodePoints(testStr);
 
-        assertThat(result.size(), is(1));
-        assertThat(result.contains("か".codePointAt(0)), is(true));
+        assertThat(result, contains("か".codePointAt(0)));
     }
 
     @Test
@@ -626,8 +626,7 @@ public class CodePointsTest {
         Set<Integer> result = new CodePoints("あいうえお").allExcludedCodePoints(
                 testStr);
 
-        assertThat(result.size(), is(1));
-        assertThat(result.contains(0x2000B), is(true));
+        assertThat(result, contains(0x2000B));
     }
 
     @Test
@@ -638,13 +637,8 @@ public class CodePointsTest {
         Set<Integer> result = new CodePoints("あいうえお").allExcludedCodePoints(
                 testStr);
 
-        assertThat(result.size(), is(5));
-        Iterator<Integer> it = result.iterator();
-        assertThat(it.next().intValue(), is(0x2000B));
-        assertThat(it.next().intValue(), is("き".codePointAt(0)));
-        assertThat(it.next().intValue(), is("か".codePointAt(0)));
-        assertThat(it.next().intValue(), is("く".codePointAt(0)));
-        assertThat(it.next().intValue(), is(0x20B9F));
+        assertThat(result, contains(0x2000B, "き".codePointAt(0), "か"
+                .codePointAt(0), "く".codePointAt(0), 0x20B9F));
     }
 
     @Test

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorJaTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorJaTest.java
@@ -16,8 +16,11 @@
 package org.terasoluna.gfw.common.codepoints.validator;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasToString;
 
 import java.util.Locale;
 import java.util.Set;
@@ -30,24 +33,24 @@ import org.junit.Test;
 
 public class ConsistOfValidatorJaTest {
 
+    private Validator validator;
+
     public ConsistOfValidatorJaTest() {
         Locale.setDefault(Locale.JAPANESE);
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
     }
 
     @Test
     public void testIsValid_message_japanese() throws Exception {
         Name_Simple name = new Name_Simple("abc", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Simple> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("firstName"));
-        assertThat(v.getMessage(), is("指定されたコードポイントで構成されていません"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("firstName")), //
+                        hasProperty("message", is("指定されたコードポイントで構成されていません")))));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
@@ -84,7 +84,7 @@ public class ConsistOfValidatorTest {
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, containsInAnyOrder( //]
+        assertThat(violations, containsInAnyOrder( //
                 allOf( //
                         hasProperty("propertyPath", hasToString("lastName")), //
                         hasProperty("message", is(

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/test/java/org/terasoluna/gfw/common/codepoints/validator/ConsistOfValidatorTest.java
@@ -15,17 +15,16 @@
  */
 package org.terasoluna.gfw.common.codepoints.validator;
 
-import static java.util.Comparator.comparing;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasToString;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -37,379 +36,313 @@ import org.junit.Test;
 
 public class ConsistOfValidatorTest {
 
+    private Validator validator;
+
     public ConsistOfValidatorTest() {
         Locale.setDefault(Locale.ENGLISH);
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
     }
 
     @Test
     public void testIsValid_all_valid() throws Exception {
         Name_Simple name = new Name_Simple("ABC", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_all_null() throws Exception {
         Name_Simple name = new Name_Simple();
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_firstName_is_invalid() throws Exception {
         Name_Simple name = new Name_Simple("abc", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Simple> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("firstName"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("firstName")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_lastName_is_invalid() throws Exception {
         Name_Simple name = new Name_Simple("ABC", "ghi");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Simple> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("lastName"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //]
+                allOf( //
+                        hasProperty("propertyPath", hasToString("lastName")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_both_are_invalid() throws Exception {
         Name_Simple name = new Name_Simple("abc", "ghi");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Simple>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(2));
-
-        Iterator<ConstraintViolation<Name_Simple>> iterator = violations
-                .iterator();
-        List<ConstraintViolation<Name_Simple>> lst = new ArrayList<ConstraintViolation<Name_Simple>>(2);
-        lst.add(iterator.next());
-        lst.add(iterator.next());
-        Collections.sort(lst,
-                new Comparator<ConstraintViolation<Name_Simple>>() {
-                    @Override
-                    public int compare(ConstraintViolation<Name_Simple> o1,
-                            ConstraintViolation<Name_Simple> o2) {
-                        return o1.getPropertyPath().toString().compareTo(o2
-                                .getPropertyPath().toString());
-                    }
-                });
-
-        assertThat(lst.get(0).getPropertyPath().toString(), is("firstName"));
-        assertThat(lst.get(0).getMessage(), is(
-                "not consist of specified code points"));
-        assertThat(lst.get(1).getPropertyPath().toString(), is("lastName"));
-        assertThat(lst.get(1).getMessage(), is(
-                "not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("firstName")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points"))), //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("lastName")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_multi_all_valid() throws Exception {
         Name_Multi name = new Name_Multi("ABCGHI", "DEFJKL");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Multi>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_multi_firstName_is_invalid() throws Exception {
         Name_Multi name = new Name_Multi("ABCDEFGHIJKLMN", "ABCDEFGHIJKL");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Multi>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+        assertThat(violations, hasSize(1));
     }
 
     @Test
     public void testIsValid_composite_all_valid() throws Exception {
         Name_Composite name = new Name_Composite("ABCGHI", "DEFJKL");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Composite>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_composite_firstName_is_invalid() throws Exception {
         Name_Composite name = new Name_Composite("ABCDEFGHIJKLMN", "ABCDEFGHIJKL");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Composite>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+        assertThat(violations, hasSize(1));
     }
 
     @Test
     public void testIsValid_getter_all_valid() throws Exception {
         Name_Getter name = new Name_Getter("ABC", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Getter>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_getter_firstName_is_invalid() throws Exception {
         Name_Getter name = new Name_Getter("abc", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Getter>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Getter> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("firstName"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("firstName")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_getter_lastName_is_invalid() throws Exception {
         Name_Getter name = new Name_Getter("ABC", "ghi");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Getter>> violations = validator.validate(
                 name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Getter> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("lastName"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("lastName")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_parameter_all_valid() throws Exception {
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_ConstructorParameter>> violations = validator
                 .forExecutables().validateConstructorParameters(
                         Name_ConstructorParameter.class.getConstructor(
                                 String.class, String.class), new Object[] {
                                         "ABC", "GHI" });
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_parameter_firstName_is_invalid() throws Exception {
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_ConstructorParameter>> violations = validator
                 .forExecutables().validateConstructorParameters(
                         Name_ConstructorParameter.class.getConstructor(
                                 String.class, String.class), new Object[] {
                                         "abc", "GHI" });
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_ConstructorParameter> v = violations.iterator()
-                .next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "Name_ConstructorParameter.arg0"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "Name_ConstructorParameter.arg0")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_parameter_lastName_is_invalid() throws Exception {
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_ConstructorParameter>> violations = validator
                 .forExecutables().validateConstructorParameters(
                         Name_ConstructorParameter.class.getConstructor(
                                 String.class, String.class), new Object[] {
                                         "ABC", "ghi" });
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_ConstructorParameter> v = violations.iterator()
-                .next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "Name_ConstructorParameter.arg1"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "Name_ConstructorParameter.arg1")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_annoattion_all_valid() throws Exception {
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_ConstructorParameter>> violations = validator
                 .forExecutables().validateConstructorParameters(
                         Name_ConstructorParameter.class.getConstructor(
                                 String.class, String.class), new Object[] {
                                         "ABC", "GHI" });
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_annotation_all_valid() throws Exception {
         Name_Annotation name = new Name_Annotation("ABC", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Annotation>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_annotation_firstName_is_invalid() throws Exception {
         Name_Annotation name = new Name_Annotation("ＡＢＣ", "GHI");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Annotation>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Annotation> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("firstName"));
-        assertThat(v.getMessage(), is("not ascii printable!"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("firstName")), //
+                        hasProperty("message", is("not ascii printable!")))));
     }
 
     @Test
     public void testIsValid_annotation_lastName_is_invalid() throws Exception {
         Name_Annotation name = new Name_Annotation("ABC", "ＧＨＩ");
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Annotation>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Annotation> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is("lastName"));
-        assertThat(v.getMessage(), is("not ascii printable!"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("lastName")), //
+                        hasProperty("message", is("not ascii printable!")))));
     }
 
     @Test
     public void testIsValid_collection_all_valid() throws Exception {
         Name_Collection name = new Name_Collection(Arrays.asList("ABC",
                 "ABC"), Arrays.asList("GHI", "GHI"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Collection>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
     public void testIsValid_collection_firstNames_is_invalid() throws Exception {
         Name_Collection name = new Name_Collection(Arrays.asList("GHI",
                 "ABC"), Arrays.asList("GHI", "GHI"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Collection>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Collection> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "firstNames[0].<list element>"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "firstNames[0].<list element>")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_collection_lastNames_is_invalid() throws Exception {
         Name_Collection name = new Name_Collection(Arrays.asList("ABC",
                 "ABC"), Arrays.asList("ABC", "GHI"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Collection>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
-
-        ConstraintViolation<Name_Collection> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "lastNames[0].<list element>"));
-        assertThat(v.getMessage(), is("not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "lastNames[0].<list element>")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
     }
 
     @Test
     public void testIsValid_collection_all_is_invalid() throws Exception {
         Name_Collection name = new Name_Collection(Arrays.asList("GHI",
                 "ABC"), Arrays.asList("GHI", "ABC"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
+
         Set<ConstraintViolation<Name_Collection>> violations = validator
                 .validate(name);
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(2));
-
-        Iterator<ConstraintViolation<Name_Collection>> iterator = violations
-                .stream().sorted(comparing(v -> v.getPropertyPath().toString()))
-                .iterator();
-
-        ConstraintViolation<Name_Collection> violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "firstNames[0].<list element>"));
-        assertThat(violation.getMessage(), is(
-                "not consist of specified code points"));
-        violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "lastNames[1].<list element>"));
-        assertThat(violation.getMessage(), is(
-                "not consist of specified code points"));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "firstNames[0].<list element>")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points"))), //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "lastNames[1].<list element>")), //
+                        hasProperty("message", is(
+                                "not consist of specified code points")))));
 
     }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/AbstractReloadableCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/AbstractReloadableCodeListTest.java
@@ -17,6 +17,8 @@ package org.terasoluna.gfw.common.codelist;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -59,9 +61,10 @@ public class AbstractReloadableCodeListTest {
         Map<String, String> mapResult1 = reloadableCodeList.asMap();
 
         // assert
-        assertThat(mapResult1.size(), is(mapExpectedFirstFetch.size()));
+        assertThat(mapResult1, aMapWithSize(mapExpectedFirstFetch.size()));
         for (String key : mapResult1.keySet()) {
-            assertThat(mapResult1.get(key), is(mapExpectedFirstFetch.get(key)));
+            assertThat(mapResult1, hasEntry(key, mapExpectedFirstFetch.get(
+                    key)));
         }
 
         // fetch codelist map for the first time
@@ -69,9 +72,9 @@ public class AbstractReloadableCodeListTest {
 
         // fetch codelist map again immediately
         Map<String, String> mapResult2 = reloadableCodeList.asMap();
-        assertThat(mapResult2.size(), is(mapExpectedSecondFetch.size()));
+        assertThat(mapResult2, aMapWithSize(mapExpectedSecondFetch.size()));
         for (String key : mapResult2.keySet()) {
-            assertThat(mapResult2.get(key), is(mapExpectedSecondFetch.get(
+            assertThat(mapResult2, hasEntry(key, mapExpectedSecondFetch.get(
                     key)));
         }
     }
@@ -102,20 +105,14 @@ public class AbstractReloadableCodeListTest {
         Map<String, String> mapResult1 = abstractReloadableCodeList.asMap();
 
         // assert
-        assertThat(mapResult1.size(), is(mapExpectedFirstFetch.size()));
-        for (String key : mapResult1.keySet()) {
-            assertThat(mapResult1.get(key), is(mapExpectedFirstFetch.get(key)));
-        }
+        assertThat(mapResult1, is(mapExpectedFirstFetch));
 
         // fetch codelist map for the first time
         abstractReloadableCodeList.afterPropertiesSet();
 
         // fetch codelist map again immediately
         Map<String, String> mapResult2 = abstractReloadableCodeList.asMap();
-        assertThat(mapResult2.size(), is(mapExpectedFirstFetch.size()));
-        for (String key : mapResult2.keySet()) {
-            assertThat(mapResult2.get(key), is(mapExpectedFirstFetch.get(key)));
-        }
+        assertThat(mapResult2, is(mapExpectedFirstFetch));
     }
 
     @Test
@@ -141,10 +138,7 @@ public class AbstractReloadableCodeListTest {
         Map<String, String> mapResult1 = reloadableCodeList.asMap();
 
         // assert
-        assertThat(mapResult1.size(), is(mapExpectedFirstFetch.size()));
-        for (String key : mapResult1.keySet()) {
-            assertThat(mapResult1.get(key), is(mapExpectedFirstFetch.get(key)));
-        }
+        assertThat(mapResult1, is(mapExpectedFirstFetch));
         assertThat(logger.isDebugEnabled(), is(false));
 
         // fetch codelist map for the first time
@@ -152,11 +146,7 @@ public class AbstractReloadableCodeListTest {
 
         // fetch codelist map again immediately
         Map<String, String> mapResult2 = reloadableCodeList.asMap();
-        assertThat(mapResult2.size(), is(mapExpectedSecondFetch.size()));
-        for (String key : mapResult2.keySet()) {
-            assertThat(mapResult2.get(key), is(mapExpectedSecondFetch.get(
-                    key)));
-        }
+        assertThat(mapResult2, is(mapExpectedSecondFetch));
 
         // init log level
         LogLevelChangeUtil.resetLogLevel();

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListJaTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListJaTest.java
@@ -17,6 +17,8 @@ package org.terasoluna.gfw.common.codelist;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
 
 import java.util.Locale;
 import java.util.Set;
@@ -46,16 +48,14 @@ public class ExistInCodeListJaTest {
     public void setUp() throws Exception {
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void test_messageJapanese() {
         Customer c = new Customer();
         c.gender = 'G';
         c.lang = "JP";
         Set<ConstraintViolation<Customer>> result = validator.validate(c);
-        assertThat(result.size(), is(1));
-        assertThat(((ConstraintViolation<Customer>) result.toArray()[0])
-                .getMessage(), is("CD_GENDER にありません"));
+        assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                "CD_GENDER にありません"))));
     }
 
     private class Customer {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/ExistInCodeListTest.java
@@ -16,17 +16,17 @@
 package org.terasoluna.gfw.common.codelist;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -67,7 +67,7 @@ public class ExistInCodeListTest {
         p.gender = "F";
         p.lang = "JP";
         Set<ConstraintViolation<Person>> result = validator.validate(p);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class ExistInCodeListTest {
         e.gender = new StringBuilder("F");
         e.lang = new StringBuilder("JP");
         Set<ConstraintViolation<Employee>> result = validator.validate(e);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ExistInCodeListTest {
         p.gender = null;
         p.lang = "JP";
         Set<ConstraintViolation<Person>> result = validator.validate(p);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class ExistInCodeListTest {
         e.gender = null;
         e.lang = new StringBuilder("JP");
         Set<ConstraintViolation<Employee>> result = validator.validate(e);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class ExistInCodeListTest {
         p.gender = "";
         p.lang = "JP";
         Set<ConstraintViolation<Person>> result = validator.validate(p);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class ExistInCodeListTest {
         e.gender = new StringBuilder("");
         e.lang = new StringBuilder("JP");
         Set<ConstraintViolation<Employee>> result = validator.validate(e);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class ExistInCodeListTest {
         p.gender = "G";
         p.lang = "JP";
         Set<ConstraintViolation<Person>> result = validator.validate(p);
-        assertThat(result.size(), is(1));
+        assertThat(result, hasSize(1));
     }
 
     @Test
@@ -130,7 +130,7 @@ public class ExistInCodeListTest {
         e.gender = new StringBuilder("G");
         e.lang = new StringBuilder("JP");
         Set<ConstraintViolation<Employee>> result = validator.validate(e);
-        assertThat(result.size(), is(1));
+        assertThat(result, hasSize(1));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class ExistInCodeListTest {
         p.gender = "G";
         p.lang = "FR";
         Set<ConstraintViolation<Person>> result = validator.validate(p);
-        assertThat(result.size(), is(2));
+        assertThat(result, hasSize(2));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ExistInCodeListTest {
         e.gender = new StringBuilder("G");
         e.lang = new StringBuilder("FR");
         Set<ConstraintViolation<Employee>> result = validator.validate(e);
-        assertThat(result.size(), is(2));
+        assertThat(result, hasSize(2));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class ExistInCodeListTest {
         c.gender = 'F';
         c.lang = "JP";
         Set<ConstraintViolation<Customer>> result = validator.validate(c);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -166,19 +166,17 @@ public class ExistInCodeListTest {
         c.gender = null;
         c.lang = "JP";
         Set<ConstraintViolation<Customer>> result = validator.validate(c);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void test_hasInValidCharacterCode() {
         Customer c = new Customer();
         c.gender = 'G';
         c.lang = "JP";
         Set<ConstraintViolation<Customer>> result = validator.validate(c);
-        assertThat(result.size(), is(1));
-        assertThat(((ConstraintViolation<Customer>) result.toArray()[0])
-                .getMessage(), is("Does not exist in CD_GENDER"));
+        assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                "Does not exist in CD_GENDER"))));
     }
 
     @Test
@@ -187,7 +185,7 @@ public class ExistInCodeListTest {
         c.gender = 'G';
         c.lang = "FR";
         Set<ConstraintViolation<Customer>> result = validator.validate(c);
-        assertThat(result.size(), is(2));
+        assertThat(result, hasSize(2));
     }
 
     @Test
@@ -196,7 +194,7 @@ public class ExistInCodeListTest {
         b.month = 1;
         b.day = 1L;
         Set<ConstraintViolation<BirthDay>> result = validator.validate(b);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -206,7 +204,7 @@ public class ExistInCodeListTest {
         b.day = 1L;
         Set<ConstraintViolation<BirthDay>> result = validator.validate(b,
                 FORMATTED.class);
-        assertThat(result.isEmpty(), is(true));
+        assertThat(result, is(empty()));
     }
 
     @Test
@@ -215,7 +213,7 @@ public class ExistInCodeListTest {
         b.month = 13;
         b.day = 32L;
         Set<ConstraintViolation<BirthDay>> result = validator.validate(b);
-        assertThat(result.size(), is(2));
+        assertThat(result, hasSize(2));
     }
 
     @Test
@@ -224,17 +222,17 @@ public class ExistInCodeListTest {
         {
             Order order = new Order(0);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.isEmpty(), is(true));
+            assertThat(result, is(empty()));
         }
         {
             Order order = new Order(6);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.isEmpty(), is(true));
+            assertThat(result, is(empty()));
         }
         {
             Order order = new Order(12);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.isEmpty(), is(true));
+            assertThat(result, is(empty()));
         }
     }
 
@@ -243,118 +241,73 @@ public class ExistInCodeListTest {
         {
             Order order = new Order(1);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(2));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be even"));
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder( //
+                    hasProperty("message", is("number must be even")), //
+                    hasProperty("message", is(
+                            "number must be multiples of 3"))));
         }
         {
             Order order = new Order(2);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(1));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                    "number must be multiples of 3"))));
         }
         {
             Order order = new Order(4);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(1));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                    "number must be multiples of 3"))));
         }
         {
             Order order = new Order(5);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(2));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be even"));
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder( //
+                    hasProperty("message", is("number must be even")), //
+                    hasProperty("message", is(
+                            "number must be multiples of 3"))));
         }
         {
             Order order = new Order(7);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(2));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be even"));
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder( //
+                    hasProperty("message", is("number must be even")), //
+                    hasProperty("message", is(
+                            "number must be multiples of 3"))));
         }
         {
             Order order = new Order(8);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(1));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                    "number must be multiples of 3"))));
         }
         {
             Order order = new Order(9);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(1));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be even"));
+            assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                    "number must be even"))));
         }
         {
             Order order = new Order(10);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(1));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder(hasProperty("message", is(
+                    "number must be multiples of 3"))));
         }
         {
             Order order = new Order(11);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(2));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be even"));
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder( //
+                    hasProperty("message", is("number must be even")), //
+                    hasProperty("message", is(
+                            "number must be multiples of 3"))));
         }
         {
             // out of range!
             Order order = new Order(18);
             Set<ConstraintViolation<Order>> result = validator.validate(order);
-            assertThat(result.size(), is(2));
-            SortedSet<String> messages = new TreeSet<String>();
-            for (ConstraintViolation<Order> violation : result) {
-                messages.add(violation.getMessage());
-            }
-            Iterator<String> iterator = messages.iterator();
-            assertThat(iterator.next(), is("number must be even"));
-            assertThat(iterator.next(), is("number must be multiples of 3"));
+            assertThat(result, containsInAnyOrder( //
+                    hasProperty("message", is("number must be even")), //
+                    hasProperty("message", is(
+                            "number must be multiples of 3"))));
         }
     }
 
@@ -364,7 +317,7 @@ public class ExistInCodeListTest {
         p.gender = "X"; // invalid value
         p.lang = "JP";
         Set<ConstraintViolation<Person>> result = validator.validate(p);
-        assertThat(result.size(), is(1));
+        assertThat(result, hasSize(1));
         ConstraintViolation<Person> error = result.iterator().next();
         assertThat(error.getMessageTemplate(), is(
                 "{org.terasoluna.gfw.common.codelist.ExistInCodeList.message}"));
@@ -379,16 +332,12 @@ public class ExistInCodeListTest {
 
     @Test
     public void issue401_testMethodValidationByInvalidValue() {
-        try {
-            codeService.getGenderLabel("U"); // call a method using invalid code value
-            fail("should be become a validation error.");
-        } catch (ConstraintViolationException e) {
-            Set<ConstraintViolation<?>> actualViolations = e
-                    .getConstraintViolations();
-            assertThat(actualViolations.size(), is(1));
-            assertThat(actualViolations.iterator().next().getMessage(), is(
-                    "Does not exist in CD_GENDER"));
-        }
+        ConstraintViolationException e = assertThrows(
+                ConstraintViolationException.class, () -> {
+                    codeService.getGenderLabel("U"); // call a method using invalid code value
+                });
+        assertThat(e.getConstraintViolations(), containsInAnyOrder(hasProperty(
+                "message", is("Does not exist in CD_GENDER"))));
     }
 
     @Test
@@ -397,9 +346,7 @@ public class ExistInCodeListTest {
         r.setRoles(Arrays.asList("M", "A", "U"));
 
         Set<ConstraintViolation<Role>> violations = validator.validate(r);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     @Test
@@ -408,9 +355,7 @@ public class ExistInCodeListTest {
         r.setRoles(Arrays.asList("M", "A", "T"));
 
         Set<ConstraintViolation<Role>> violations = validator.validate(r);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+        assertThat(violations, hasSize(1));
     }
 
     @Test
@@ -419,9 +364,7 @@ public class ExistInCodeListTest {
         r.setRoles(Arrays.asList("S", "A", "T"));
 
         Set<ConstraintViolation<Role>> violations = validator.validate(r);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(2));
+        assertThat(violations, hasSize(2));
     }
 
     @Validated

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/JdbcCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/JdbcCodeListTest.java
@@ -18,6 +18,7 @@ package org.terasoluna.gfw.common.codelist;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -91,11 +92,7 @@ public class JdbcCodeListTest {
 
         Map<String, String> mapOutput = jdbcCodeList.retrieveMap();
 
-        assertThat(mapOutput.size(), is(mapInput.size()));
-        for (int i = 0; i < 10; i++) {
-            assertThat(mapOutput.get(String.format("%03d", i)), is(mapInput.get(
-                    String.format("%03d", i))));
-        }
+        assertThat(mapOutput, is(mapInput));
 
     }
 
@@ -115,12 +112,7 @@ public class JdbcCodeListTest {
         jdbcCodeList.setQuerySql(
                 "Select code_id, code_name_temp from codelist");
 
-        Map<String, String> mapOutput = jdbcCodeList.retrieveMap();
-
-        assertThat(mapOutput.size(), is(mapInput.size()));
-        for (int i = 0; i < 10; i++) {
-            assertThat(mapOutput.get("%03d"), is(mapInput.get("%03d")));
-        }
+        jdbcCodeList.retrieveMap();
 
     }
 
@@ -141,11 +133,7 @@ public class JdbcCodeListTest {
 
         Map<String, String> mapOutput = jdbcCodeList.retrieveMap();
 
-        assertThat(mapOutput.size(), is(mapInput.size()));
-        for (int i = 0; i < 10; i++) {
-            assertThat(mapOutput.get(String.format("%03d", i)), is(mapInput.get(
-                    String.format("%03d", i))));
-        }
+        assertThat(mapOutput, is(mapInput));
 
     }
 
@@ -163,7 +151,7 @@ public class JdbcCodeListTest {
         Map<String, String> mapOutput = jdbcCodeList.retrieveMap();
 
         // assert
-        assertThat(mapOutput.size(), is(0));
+        assertThat(mapOutput, is(anEmptyMap()));
 
     }
 
@@ -181,7 +169,7 @@ public class JdbcCodeListTest {
         Map<String, String> mapOutput = jdbcCodeList.retrieveMap();
 
         // assert
-        assertThat(mapOutput.size(), is(0));
+        assertThat(mapOutput, is(anEmptyMap()));
 
     }
 
@@ -199,7 +187,7 @@ public class JdbcCodeListTest {
         Map<String, String> mapOutput = jdbcCodeList.retrieveMap();
 
         // assert
-        assertThat(mapOutput.size(), is(0));
+        assertThat(mapOutput, is(anEmptyMap()));
 
     }
 
@@ -234,10 +222,7 @@ public class JdbcCodeListTest {
         Map<String, String> exposedMapSecondFetch = (Map<String, String>) f.get(
                 jdbcCodeList);
         // assert
-        assertThat(exposedMapSecondFetch.size(), is(mapInput.size()));
-        for (String key : exposedMapSecondFetch.keySet()) {
-            assertThat(exposedMapSecondFetch.get(key), is(mapInput.get(key)));
-        }
+        assertThat(exposedMapSecondFetch, is(mapInput));
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeListTest.java
@@ -53,10 +53,7 @@ public class NumberRangeCodeListTest {
         Map<String, String> mapResult = numberRangeCodeList.asMap();
 
         // check that the codelist is initialized with range of numbers
-        assertThat(mapResult.size(), is(mapTest.size()));
-        for (String key : mapResult.keySet()) {
-            assertThat(mapResult.get(key), is(mapTest.get(key)));
-        }
+        assertThat(mapResult, is(mapTest));
 
         // check the order of range of numbers
         assertThat(mapResult.equals(mapTest), is(true));

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/AbstractI18nCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/AbstractI18nCodeListTest.java
@@ -15,8 +15,8 @@
  */
 package org.terasoluna.gfw.common.codelist.i18n;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -47,19 +47,19 @@ public class AbstractI18nCodeListTest {
         };
 
         Locale.setDefault(Locale.ENGLISH);
-        assertThat(impl.asMap().get("language"), is(Locale.ENGLISH
+        assertThat(impl.asMap(), hasEntry("language", Locale.ENGLISH
                 .getLanguage()));
 
         LocaleContextHolder.setLocale(Locale.GERMAN);
-        assertThat(impl.asMap().get("language"), is(Locale.GERMAN
+        assertThat(impl.asMap(), hasEntry("language", Locale.GERMAN
                 .getLanguage()));
 
         LocaleContextHolder.setLocale(Locale.FRENCH);
-        assertThat(impl.asMap().get("language"), is(Locale.FRENCH
+        assertThat(impl.asMap(), hasEntry("language", Locale.FRENCH
                 .getLanguage()));
 
         Locale.setDefault(Locale.JAPANESE);
-        assertThat(impl.asMap().get("language"), is(Locale.FRENCH
+        assertThat(impl.asMap(), hasEntry("language", Locale.FRENCH
                 .getLanguage()));
     }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/SimpleI18nCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/SimpleI18nCodeListTest.java
@@ -19,7 +19,9 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Locale;
 import java.util.Map;
@@ -67,15 +69,15 @@ public class SimpleI18nCodeListTest extends ApplicationObjectSupport {
 
         Map<String, String> row1 = testSetRows.asMap();
         assertThat(row1, is(notNullValue()));
-        assertThat(row1.keySet().toString(), is("[0, 1, 2, 3, 4, 5, 6]"));
+        assertThat(row1, aMapWithSize(7));
 
-        assertThat(row1.get("0"), is("Sun."));
-        assertThat(row1.get("1"), is("Mon."));
-        assertThat(row1.get("2"), is("Tue."));
-        assertThat(row1.get("3"), is("Wed."));
-        assertThat(row1.get("4"), is("Thu."));
-        assertThat(row1.get("5"), is("Fri."));
-        assertThat(row1.get("6"), is("Sat."));
+        assertThat(row1, hasEntry("0", "Sun."));
+        assertThat(row1, hasEntry("1", "Mon."));
+        assertThat(row1, hasEntry("2", "Tue."));
+        assertThat(row1, hasEntry("3", "Wed."));
+        assertThat(row1, hasEntry("4", "Thu."));
+        assertThat(row1, hasEntry("5", "Fri."));
+        assertThat(row1, hasEntry("6", "Sat."));
     }
 
     @Test
@@ -83,33 +85,32 @@ public class SimpleI18nCodeListTest extends ApplicationObjectSupport {
 
         Map<String, String> row1 = testSetRows.asMap(Locale.ENGLISH);
         assertThat(row1, is(notNullValue()));
-        assertThat(row1.keySet().toString(), is("[0, 1, 2, 3, 4, 5, 6]"));
+        assertThat(row1, aMapWithSize(7));
 
-        assertThat(row1.get("0"), is("Sun."));
-        assertThat(row1.get("1"), is("Mon."));
-        assertThat(row1.get("2"), is("Tue."));
-        assertThat(row1.get("3"), is("Wed."));
-        assertThat(row1.get("4"), is("Thu."));
-        assertThat(row1.get("5"), is("Fri."));
-        assertThat(row1.get("6"), is("Sat."));
+        assertThat(row1, hasEntry("0", "Sun."));
+        assertThat(row1, hasEntry("1", "Mon."));
+        assertThat(row1, hasEntry("2", "Tue."));
+        assertThat(row1, hasEntry("3", "Wed."));
+        assertThat(row1, hasEntry("4", "Thu."));
+        assertThat(row1, hasEntry("5", "Fri."));
+        assertThat(row1, hasEntry("6", "Sat."));
 
         Map<String, String> row2 = testSetRows.asMap(Locale.JAPANESE);
         assertThat(row2, is(notNullValue()));
-        assertThat(row2.keySet().toString(), is("[0, 1, 2, 3, 4, 5, 6]"));
+        assertThat(row2, aMapWithSize(7));
 
-        assertThat(row2.get("0"), is("日"));
-        assertThat(row2.get("1"), is("月"));
-        assertThat(row2.get("2"), is("火"));
-        assertThat(row2.get("3"), is("水"));
-        assertThat(row2.get("4"), is("木"));
-        assertThat(row2.get("5"), is("金"));
-        assertThat(row2.get("6"), is("土"));
+        assertThat(row2, hasEntry("0", "日"));
+        assertThat(row2, hasEntry("1", "月"));
+        assertThat(row2, hasEntry("2", "火"));
+        assertThat(row2, hasEntry("3", "水"));
+        assertThat(row2, hasEntry("4", "木"));
+        assertThat(row2, hasEntry("5", "金"));
+        assertThat(row2, hasEntry("6", "土"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testAsMapCheckUnmodifiable() {
         testSetRows.asMap(Locale.ENGLISH).put("0", "Sunday");
-        fail("UnsupportedOperationException not occered.");
     }
 
     @Test
@@ -139,65 +140,64 @@ public class SimpleI18nCodeListTest extends ApplicationObjectSupport {
     @Test
     public void testSetFallbackToNull() {
         SimpleI18nCodeList codeList = new SimpleI18nCodeList();
-        try {
-            codeList.setFallbackTo(null);
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("fallbackTo must not be null"));
-        }
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    codeList.setFallbackTo(null);
+                });
+        assertThat(e.getMessage(), is("fallbackTo must not be null"));
     }
 
     @Test
     public void testSetFallbackToInvalidLanguage() {
-        try {
-            super.getApplicationContext().getBean(
-                    "CL_testFallbackToInvalidLanguage");
-            fail("BeanCreationException not occered.");
-        } catch (BeanCreationException e) {
-            Throwable cause = e.getCause();
-            assertThat(cause, instanceOf(IllegalArgumentException.class));
-            assertThat(cause.getMessage(), is(
-                    "No codelist found for fallback locale 'fr', it must be defined."));
-        }
+        BeanCreationException e = assertThrows(BeanCreationException.class,
+                () -> {
+                    super.getApplicationContext().getBean(
+                            "CL_testFallbackToInvalidLanguage");
+                });
+        Throwable cause = e.getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertThat(cause.getMessage(), is(
+                "No codelist found for fallback locale 'fr', it must be defined."));
     }
 
     @Test
     public void testSetFallbackToInvalidLanguageMatchingNation() {
-        try {
-            super.getApplicationContext().getBean(
-                    "CL_testFallbackToInvalidLanguageMatchingNation");
-            fail("BeanCreationException not occered.");
-        } catch (BeanCreationException e) {
-            Throwable cause = e.getCause();
-            assertThat(cause, instanceOf(IllegalArgumentException.class));
-            assertThat(cause.getMessage(), is(
-                    "No codelist found for fallback locale 'en_US', it must be defined."));
-        }
+        BeanCreationException e = assertThrows(BeanCreationException.class,
+                () -> {
+                    super.getApplicationContext().getBean(
+                            "CL_testFallbackToInvalidLanguageMatchingNation");
+                });
+        Throwable cause = e.getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertThat(cause.getMessage(), is(
+                "No codelist found for fallback locale 'en_US', it must be defined."));
     }
 
     @Test
     public void testAfterProperitesSetInvalidInitializedCodeList() {
         SimpleI18nCodeList codeList = new SimpleI18nCodeList();
-        try {
-            codeList.afterPropertiesSet();
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("codeListTable is not initialized!"));
-        }
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    codeList.afterPropertiesSet();
+                });
+        assertThat(e.getMessage(), is("codeListTable is not initialized!"));
 
     }
 
     @Test
     public void testAfterProperitesSetInvalidResolveDefaultLocale() {
-        try {
-            super.getApplicationContext().getBean(
-                    "CL_testAfterPropertiesSetInvalidResolveDefaultLocale");
-            fail("BeanCreationException not occered.");
-        } catch (BeanCreationException e) {
-            Throwable cause = e.getCause();
-            assertThat(cause, instanceOf(IllegalArgumentException.class));
-            assertThat(cause.getMessage(), is(
-                    "No codelist for default locale ('en_US' and 'en'). "
-                            + "Please define codelist for default locale or set locale already defined in codelist to fallbackTo."));
-        }
+        BeanCreationException e = assertThrows(BeanCreationException.class,
+                () -> {
+                    super.getApplicationContext().getBean(
+                            "CL_testAfterPropertiesSetInvalidResolveDefaultLocale");
+                });
+        Throwable cause = e.getCause();
+        assertThat(cause, instanceOf(IllegalArgumentException.class));
+        assertThat(cause.getMessage(), is(
+                "No codelist for default locale ('en_US' and 'en'). "
+                        + "Please define codelist for default locale or set locale already defined in codelist to fallbackTo."));
     }
 
     @Test

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/SimpleReloadableI18nCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/i18n/SimpleReloadableI18nCodeListTest.java
@@ -18,6 +18,7 @@ package org.terasoluna.gfw.common.codelist.i18n;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
 
 import java.util.Locale;
 import java.util.Map;
@@ -224,7 +225,7 @@ public class SimpleReloadableI18nCodeListTest {
             Map<String, String> mapInput = tableInput.row(locale);
             Map<String, String> mapOutput = reloadableI18nCodeList.asMap(
                     locale);
-            assertThat(mapOutput.size(), is(mapSize));
+            assertThat(mapOutput, aMapWithSize(mapSize));
             for (int i = 0; i < mapSize; i++) {
                 assertThat(mapOutput.get(String.format("%03d", i)), is(mapInput
                         .get(String.format("%03d", i))));

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/exception/ResultMessagesLoggingInterceptorTest.java
@@ -17,7 +17,10 @@ package org.terasoluna.gfw.common.exception;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -116,16 +119,14 @@ public class ResultMessagesLoggingInterceptorTest extends
         BusinessException occurException = new BusinessException("testing businessexception");
         when(mockMethodInvocation.proceed()).thenThrow(occurException);
 
-        try {
+        BusinessException e = assertThrows(BusinessException.class, () -> {
             // do test.
             testTarget.invoke(mockMethodInvocation);
-            fail("didn't occured BusinessException.");
-        } catch (BusinessException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
-        }
+        });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, times(1)).warn(occurException);
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
 
     }
 
@@ -147,16 +148,14 @@ public class ResultMessagesLoggingInterceptorTest extends
                 .error().add("e.cm.xxx1", "args1", "args2"));
         when(mockMethodInvocation.proceed()).thenThrow(occurException);
 
-        try {
+        BusinessException e = assertThrows(BusinessException.class, () -> {
             // do test.
             testTarget.invoke(mockMethodInvocation);
-            fail("don't occur BusinessException.");
-        } catch (BusinessException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
-        }
+        });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, times(1)).warn(occurException);
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
 
     }
 
@@ -167,16 +166,14 @@ public class ResultMessagesLoggingInterceptorTest extends
                 .error().add("e.cm.xxx1", "args1", "args2"), null);
         when(mockMethodInvocation.proceed()).thenThrow(occurException);
 
-        try {
+        BusinessException e = assertThrows(BusinessException.class, () -> {
             // do test.
             testTarget.invoke(mockMethodInvocation);
-            fail("don't occur BusinessException.");
-        } catch (BusinessException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
-        }
+        });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, times(1)).warn(occurException);
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
 
     }
 
@@ -189,18 +186,17 @@ public class ResultMessagesLoggingInterceptorTest extends
                 TestService.class);
         service.setResultMessagesNotificationException(occurException);
 
-        try {
-            // do test.
-            TestFacade facade = getApplicationContext().getBean(
-                    TestFacade.class);
-            facade.getMessage();
-            fail("don't occur ResourceNotFoundException.");
-        } catch (ResourceNotFoundException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
-        }
+        ResourceNotFoundException e = assertThrows(
+                ResourceNotFoundException.class, () -> {
+                    // do test.
+                    TestFacade facade = getApplicationContext().getBean(
+                            TestFacade.class);
+                    facade.getMessage();
+                });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, times(1)).warn(occurException);
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
 
     }
 
@@ -229,18 +225,17 @@ public class ResultMessagesLoggingInterceptorTest extends
                 TestService.class);
         service.setResultMessagesNotificationException(occurException);
 
-        try {
-            // do test.
-            TestFacade facade = getApplicationContext().getBean(
-                    TestFacade.class);
-            facade.getMessage();
-            fail("don't occur ResourceNotFoundException.");
-        } catch (ResourceNotFoundException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
-        }
+        ResourceNotFoundException e = assertThrows(
+                ResourceNotFoundException.class, () -> {
+                    // do test.
+                    TestFacade facade = getApplicationContext().getBean(
+                            TestFacade.class);
+                    facade.getMessage();
+                });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, times(1)).warn(occurException);
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
 
     }
 
@@ -254,18 +249,17 @@ public class ResultMessagesLoggingInterceptorTest extends
                 TestService.class);
         service.setResultMessagesNotificationException(occurException);
 
-        try {
-            // do test.
-            TestFacade facade = getApplicationContext().getBean(
-                    TestFacade.class);
-            facade.getMessage();
-            fail("don't occur ResourceNotFoundException.");
-        } catch (ResourceNotFoundException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, times(1)).warn(occurException);
-            verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
-        }
+        ResourceNotFoundException e = assertThrows(
+                ResourceNotFoundException.class, () -> {
+                    // do test.
+                    TestFacade facade = getApplicationContext().getBean(
+                            TestFacade.class);
+                    facade.getMessage();
+                });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, times(1)).warn(occurException);
+        verify(mockExceptionLogger, times(1)).warn(any(Exception.class));
 
     }
 
@@ -286,15 +280,14 @@ public class ResultMessagesLoggingInterceptorTest extends
         NullPointerException occurException = new NullPointerException("testInvoke_occur_other_exception");
         when(mockMethodInvocation.proceed()).thenThrow(occurException);
 
-        try {
-            // do test.
-            testTarget.invoke(mockMethodInvocation);
-            fail("don't occur NullPointerException.");
-        } catch (NullPointerException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-            verify(mockExceptionLogger, never()).warn(any(Exception.class));
-        }
+        NullPointerException e = assertThrows(NullPointerException.class,
+                () -> {
+                    // do test.
+                    testTarget.invoke(mockMethodInvocation);
+                });
+        // do assert.
+        assertThat(e, is(occurException));
+        verify(mockExceptionLogger, never()).warn(any(Exception.class));
 
     }
 
@@ -319,21 +312,15 @@ public class ResultMessagesLoggingInterceptorTest extends
 
         // do test.
         // 1st intercept.
-        try {
+        BusinessException e = assertThrows(BusinessException.class, () -> {
             testTarget.invoke(mockMethodInvocation);
-            fail("don't occur BusinessException.");
-        } catch (BusinessException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-        }
+        });
+        assertThat(e, is(occurException));
         // 2nd intercept.
-        try {
+        e = assertThrows(BusinessException.class, () -> {
             testTarget.invoke(mockMethodInvocation);
-            fail("don't occur BusinessException.");
-        } catch (BusinessException e) {
-            // do assert.
-            assertThat(e, is(occurException));
-        }
+        });
+        assertThat(e, is(occurException));
 
         // do assert.
         verify(mockExceptionLogger, times(2)).warn(occurException);
@@ -360,21 +347,15 @@ public class ResultMessagesLoggingInterceptorTest extends
         final Map<Thread, String> actualMessage = new HashMap<Thread, String>();
 
         // setup for thread1.
-        Thread thread1 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                facade.setSleepTime(Long.valueOf(2));
-                actualMessage.put(Thread.currentThread(), facade.getMessage());
-            }
+        Thread thread1 = new Thread(() -> {
+            facade.setSleepTime(Long.valueOf(2));
+            actualMessage.put(Thread.currentThread(), facade.getMessage());
         });
 
         // setup for thread2.
-        Thread thread2 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                facade.setSleepTime(Long.valueOf(0));
-                actualMessage.put(Thread.currentThread(), facade.getMessage());
-            }
+        Thread thread2 = new Thread(() -> {
+            facade.setSleepTime(Long.valueOf(0));
+            actualMessage.put(Thread.currentThread(), facade.getMessage());
         });
 
         // do test.
@@ -389,12 +370,12 @@ public class ResultMessagesLoggingInterceptorTest extends
         // do assert.
         String expectedBaseMessage = getApplicationContext().getBean(
                 TestRepository.class).toString() + ":";
-        assertThat(actualMessage.get(thread1), is(expectedBaseMessage + thread1
-                .getId()));
-        assertThat(actualMessage.get(thread2), is(expectedBaseMessage + thread2
-                .getId()));
+        assertThat(actualMessage, hasEntry(thread1, expectedBaseMessage
+                + thread1.getId()));
+        assertThat(actualMessage, hasEntry(thread2, expectedBaseMessage
+                + thread2.getId()));
 
-        verify(mockExceptionLogger, never()).warn((Exception) any());
+        verify(mockExceptionLogger, never()).warn(any(Exception.class));
     }
 
     /**
@@ -421,34 +402,28 @@ public class ResultMessagesLoggingInterceptorTest extends
         // setup for thread1.
         final BusinessException occurExceptionForThread1 = new BusinessException(ResultMessages
                 .error().add("e.cm.thread1"));
-        Thread thread1 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                service.setResultMessagesNotificationException(
-                        occurExceptionForThread1);
-                facade.setSleepTime(Long.valueOf(2));
-                try {
-                    facade.getMessage();
-                } catch (BusinessException e) {
-                    actualBusinessException.put(Thread.currentThread(), e);
-                }
+        Thread thread1 = new Thread(() -> {
+            service.setResultMessagesNotificationException(
+                    occurExceptionForThread1);
+            facade.setSleepTime(Long.valueOf(2));
+            try {
+                facade.getMessage();
+            } catch (BusinessException e) {
+                actualBusinessException.put(Thread.currentThread(), e);
             }
         });
 
         // setup for thread2.
         final BusinessException occurExceptionForThread2 = new BusinessException(ResultMessages
                 .error().add("e.cm.thread2"));
-        Thread thread2 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                service.setResultMessagesNotificationException(
-                        occurExceptionForThread2);
-                facade.setSleepTime(Long.valueOf(0));
-                try {
-                    facade.getMessage();
-                } catch (BusinessException e) {
-                    actualBusinessException.put(Thread.currentThread(), e);
-                }
+        Thread thread2 = new Thread(() -> {
+            service.setResultMessagesNotificationException(
+                    occurExceptionForThread2);
+            facade.setSleepTime(Long.valueOf(0));
+            try {
+                facade.getMessage();
+            } catch (BusinessException e) {
+                actualBusinessException.put(Thread.currentThread(), e);
             }
         });
 
@@ -462,9 +437,9 @@ public class ResultMessagesLoggingInterceptorTest extends
         thread2.join();
 
         // do assert
-        assertThat(actualBusinessException.get(thread1), is(
+        assertThat(actualBusinessException, hasEntry(thread1,
                 occurExceptionForThread1));
-        assertThat(actualBusinessException.get(thread2), is(
+        assertThat(actualBusinessException, hasEntry(thread2,
                 occurExceptionForThread2));
 
         verify(mockExceptionLogger, times(1)).warn(occurExceptionForThread1);
@@ -494,32 +469,26 @@ public class ResultMessagesLoggingInterceptorTest extends
         final Map<Thread, BusinessException> actualBusinessException = new HashMap<Thread, BusinessException>();
 
         // setup for thread1.
-        Thread thread1 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                facade.setSleepTime(Long.valueOf(2));
-                try {
-                    facade.getMessage();
-                } catch (BusinessException e) {
-                    actualBusinessException.put(Thread.currentThread(), e);
-                }
+        Thread thread1 = new Thread(() -> {
+            facade.setSleepTime(Long.valueOf(2));
+            try {
+                facade.getMessage();
+            } catch (BusinessException e) {
+                actualBusinessException.put(Thread.currentThread(), e);
             }
         });
 
         // setup for thread2.
         final BusinessException occurExceptionForThread2 = new BusinessException(ResultMessages
                 .error().add("e.cm.thread2"));
-        Thread thread2 = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                service.setResultMessagesNotificationException(
-                        occurExceptionForThread2);
-                facade.setSleepTime(Long.valueOf(0));
-                try {
-                    facade.getMessage();
-                } catch (BusinessException e) {
-                    actualBusinessException.put(Thread.currentThread(), e);
-                }
+        Thread thread2 = new Thread(() -> {
+            service.setResultMessagesNotificationException(
+                    occurExceptionForThread2);
+            facade.setSleepTime(Long.valueOf(0));
+            try {
+                facade.getMessage();
+            } catch (BusinessException e) {
+                actualBusinessException.put(Thread.currentThread(), e);
             }
         });
 
@@ -533,8 +502,8 @@ public class ResultMessagesLoggingInterceptorTest extends
         thread2.join();
 
         // do assert
-        assertThat(actualBusinessException.containsKey(thread1), is(false));
-        assertThat(actualBusinessException.get(thread2), is(
+        assertThat(actualBusinessException, not(hasKey(thread1)));
+        assertThat(actualBusinessException, hasEntry(thread2,
                 occurExceptionForThread2));
 
         verify(mockExceptionLogger, times(1)).warn(occurExceptionForThread2);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageTest.java
@@ -15,16 +15,18 @@
  */
 package org.terasoluna.gfw.common.message;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.emptyArray;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
-import org.springframework.core.serializer.support.SerializationFailedException;
+import org.junit.Test.None;
 import org.springframework.util.SerializationUtils;
 
 public class ResultMessageTest {
@@ -35,7 +37,7 @@ public class ResultMessageTest {
 
         assertThat(message.getText(), is("text"));
         assertThat(message.getCode(), is(nullValue()));
-        assertThat(message.getArgs(), is(new Object[] {}));
+        assertThat(message.getArgs(), is(emptyArray()));
     }
 
     @Test
@@ -44,7 +46,7 @@ public class ResultMessageTest {
 
         assertThat(message.getText(), is(nullValue()));
         assertThat(message.getCode(), is("xxx.yyy.code"));
-        assertThat(message.getArgs(), is(new Object[] {}));
+        assertThat(message.getArgs(), is(emptyArray()));
     }
 
     @Test
@@ -55,7 +57,7 @@ public class ResultMessageTest {
 
         assertThat(message.getText(), is(nullValue()));
         assertThat(message.getCode(), is("xxx.yyy.code"));
-        assertThat(message.getArgs(), is(new Object[] { "a", 1, "x" }));
+        assertThat(message.getArgs(), arrayContaining("a", 1, "x"));
     }
 
     @Test
@@ -65,7 +67,7 @@ public class ResultMessageTest {
 
         assertThat(message.getText(), is(nullValue()));
         assertThat(message.getCode(), is("xxx.yyy.code"));
-        assertThat(message.getArgs(), is(new Object[] {}));
+        assertThat(message.getArgs(), is(emptyArray()));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -83,15 +85,11 @@ public class ResultMessageTest {
         ResultMessage.fromText(null);
     }
 
-    @Test
+    @Test(expected = None.class)
     public void test10() {
-        try {
-            byte[] serialized = SerializationUtils.serialize(ResultMessage
-                    .fromText("foo"));
-            SerializationUtils.deserialize(serialized);
-        } catch (SerializationFailedException e) {
-            fail();
-        }
+        byte[] serialized = SerializationUtils.serialize(ResultMessage.fromText(
+                "foo"));
+        SerializationUtils.deserialize(serialized);
     }
 
     @Test
@@ -120,10 +118,10 @@ public class ResultMessageTest {
         set.add(msg1);
         set.add(msg2);
         set.add(msg3);
-        assertThat(set.contains(msg1), is(true));
-        assertThat(set.contains(ResultMessage.fromText("foo")), is(true));
-        assertThat(set.contains(ResultMessage.fromCode("foo")), is(true));
-        assertThat(set.contains(ResultMessage.fromCode("foo", "a")), is(true));
+        assertThat(set, hasItem(msg1));
+        assertThat(set, hasItem(ResultMessage.fromText("foo")));
+        assertThat(set, hasItem(ResultMessage.fromCode("foo")));
+        assertThat(set, hasItem(ResultMessage.fromCode("foo", "a")));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessagesTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessagesTest.java
@@ -17,7 +17,7 @@ package org.terasoluna.gfw.common.message;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.contains;
 import static org.terasoluna.gfw.common.message.StandardResultMessageType.DANGER;
 import static org.terasoluna.gfw.common.message.StandardResultMessageType.ERROR;
 import static org.terasoluna.gfw.common.message.StandardResultMessageType.INFO;
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Test;
-import org.springframework.core.serializer.support.SerializationFailedException;
+import org.junit.Test.None;
 import org.springframework.util.SerializationUtils;
 
 public class ResultMessagesTest {
@@ -42,8 +42,8 @@ public class ResultMessagesTest {
 
     @Test
     public void testGetType() {
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
-        assertThat(messages.getType(), is((ResultMessageType) ERROR));
+        ResultMessages messages = new ResultMessages(ERROR);
+        assertThat(messages.getType(), is(ERROR));
     }
 
     @Test
@@ -51,8 +51,8 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo");
         ResultMessage msg2 = ResultMessage.fromCode("bar");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR, msg1, msg2);
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        ResultMessages messages = new ResultMessages(ERROR, msg1, msg2);
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test
@@ -60,17 +60,16 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo");
         ResultMessage msg2 = ResultMessage.fromCode("bar");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR, msg1);
+        ResultMessages messages = new ResultMessages(ERROR, msg1);
         messages.add(msg2);
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
-        System.out.println(messages);
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAdd02_null() {
         ResultMessage msg1 = ResultMessage.fromCode("foo");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR, msg1);
+        ResultMessages messages = new ResultMessages(ERROR, msg1);
         messages.add((ResultMessage) null);
     }
 
@@ -79,9 +78,9 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromText("foo");
         ResultMessage msg2 = ResultMessage.fromText("bar");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR, msg1);
+        ResultMessages messages = new ResultMessages(ERROR, msg1);
         messages.add(msg2);
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getList(), contains(msg1, msg2));
         System.out.println(messages);
     }
 
@@ -90,15 +89,15 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo");
         ResultMessage msg2 = ResultMessage.fromCode("bar");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.add("foo");
         messages.add("bar");
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAdd12_null() {
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.add("foo");
         messages.add((String) null);
     }
@@ -108,16 +107,16 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo", "aa");
         ResultMessage msg2 = ResultMessage.fromCode("bar", "bb");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.add("foo", "aa");
         messages.add("bar", "bb");
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAdd22_null() {
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.add("foo", "aa");
         messages.add((String) null, "bb");
     }
@@ -127,15 +126,15 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo", "aa");
         ResultMessage msg2 = ResultMessage.fromCode("bar", "bb");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.addAll(msg1, msg2);
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAddAll02_null() {
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.addAll((ResultMessage[]) null);
     }
 
@@ -144,28 +143,27 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo", "aa");
         ResultMessage msg2 = ResultMessage.fromCode("bar", "bb");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.addAll(Arrays.asList(msg1, msg2));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testAddAll12_null() {
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.addAll((Collection<ResultMessage>) null);
     }
 
     @Test
     public void testIsNotEmpty01() {
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR)
-                .add("foo");
+        ResultMessages messages = new ResultMessages(ERROR).add("foo");
         assertThat(messages.isNotEmpty(), is(true));
     }
 
     @Test
     public void testIsNotEmpty02() {
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         assertThat(messages.isNotEmpty(), is(false));
     }
 
@@ -174,7 +172,7 @@ public class ResultMessagesTest {
         ResultMessage msg1 = ResultMessage.fromCode("foo", "aa");
         ResultMessage msg2 = ResultMessage.fromCode("bar", "bb");
 
-        ResultMessages messages = new ResultMessages((ResultMessageType) ERROR);
+        ResultMessages messages = new ResultMessages(ERROR);
         messages.addAll(Arrays.asList(msg1, msg2));
 
         List<ResultMessage> result = new ArrayList<ResultMessage>();
@@ -182,7 +180,7 @@ public class ResultMessagesTest {
             result.add(message);
         }
 
-        assertThat(result, is(Arrays.asList(msg1, msg2)));
+        assertThat(result, contains(msg1, msg2));
     }
 
     @Test
@@ -193,8 +191,8 @@ public class ResultMessagesTest {
         ResultMessages messages = ResultMessages.error().add("foo", "aa").add(
                 "bar", "bb");
 
-        assertThat(messages.getType(), is((ResultMessageType) ERROR));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getType(), is(ERROR));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @SuppressWarnings("deprecation")
@@ -206,8 +204,8 @@ public class ResultMessagesTest {
         ResultMessages messages = ResultMessages.warn().add("foo", "aa").add(
                 "bar", "bb");
 
-        assertThat(messages.getType(), is((ResultMessageType) WARN));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getType(), is(WARN));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test
@@ -218,8 +216,8 @@ public class ResultMessagesTest {
         ResultMessages messages = ResultMessages.info().add("foo", "aa").add(
                 "bar", "bb");
 
-        assertThat(messages.getType(), is((ResultMessageType) INFO));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getType(), is(INFO));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test
@@ -230,8 +228,8 @@ public class ResultMessagesTest {
         ResultMessages messages = ResultMessages.success().add("foo", "aa").add(
                 "bar", "bb");
 
-        assertThat(messages.getType(), is((ResultMessageType) SUCCESS));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getType(), is(SUCCESS));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test
@@ -242,8 +240,8 @@ public class ResultMessagesTest {
         ResultMessages messages = ResultMessages.danger().add("foo", "aa").add(
                 "bar", "bb");
 
-        assertThat(messages.getType(), is((ResultMessageType) DANGER));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getType(), is(DANGER));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
     @Test
@@ -254,18 +252,14 @@ public class ResultMessagesTest {
         ResultMessages messages = ResultMessages.warning().add("foo", "aa").add(
                 "bar", "bb");
 
-        assertThat(messages.getType(), is((ResultMessageType) WARNING));
-        assertThat(messages.getList(), is(Arrays.asList(msg1, msg2)));
+        assertThat(messages.getType(), is(WARNING));
+        assertThat(messages.getList(), contains(msg1, msg2));
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testSerialization() {
-        try {
-            byte[] serialized = SerializationUtils.serialize(
-                    new ResultMessages((ResultMessageType) ERROR));
-            SerializationUtils.deserialize(serialized);
-        } catch (SerializationFailedException e) {
-            fail();
-        }
+        byte[] serialized = SerializationUtils.serialize(
+                new ResultMessages(ERROR));
+        SerializationUtils.deserialize(serialized);
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-security-web/src/test/java/org/terasoluna/gfw/security/web/redirect/RedirectAuthenticationHandlerTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-security-web/src/test/java/org/terasoluna/gfw/security/web/redirect/RedirectAuthenticationHandlerTest.java
@@ -19,18 +19,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.DefaultRedirectStrategy;
-import org.springframework.security.web.RedirectStrategy;
 
 @SuppressWarnings("deprecation")
 public class RedirectAuthenticationHandlerTest {
@@ -232,13 +226,9 @@ public class RedirectAuthenticationHandlerTest {
     @Test
     public void testOnAuthenticationSuccess_SetCustomeRedirectToRedirectStrategy() throws Exception {
         RedirectAuthenticationHandler redireHandler = new RedirectAuthenticationHandler();
-        redireHandler.setRedirectToRedirectStrategy(new RedirectStrategy() {
-            @Override
-            public void sendRedirect(HttpServletRequest request,
-                    HttpServletResponse response,
-                    String url) throws IOException {
-                response.sendRedirect("http://google.com");
-            }
+        redireHandler.setRedirectToRedirectStrategy((request, response,
+                url) -> {
+            response.sendRedirect("http://google.com");
         });
         redireHandler.afterPropertiesSet();
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfConverterTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfConverterTest.java
@@ -53,20 +53,16 @@ public class FullHalfConverterTest {
     public void testWithCustomAppenadablePredicate() {
         FullHalfConverter converter = new FullHalfConverter(new FullHalfPairsBuilder()
                 .pair("バ", "ﾊﾞ").pair("ハ", "ﾊ").pair("゛", "ﾞ").pair("゜", "ﾟ")
-                .appendablePredicate(new FullHalfPairs.AppendablePredicate() {
-                    @Override
-                    public boolean isAppendable(char c) {
-                        return c == 'ﾞ';
-                    }
-                }).build());
+                .appendablePredicate(c -> c == 'ﾞ').build());
         assertThat(converter.toFullwidth("ﾊﾞ"), is("バ"));
         assertThat(converter.toFullwidth("ﾊﾟ"), is("ハ゜"));
     }
 
     @Test
     public void testNull() {
-        Exception ex = assertThrows(IllegalArgumentException.class,
-                () -> new FullHalfConverter(null));
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> {
+            new FullHalfConverter(null);
+        });
         assertThat(ex.getMessage(), is("pairs must not be null."));
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsBuilderTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/FullHalfPairsBuilderTest.java
@@ -17,6 +17,7 @@ package org.terasoluna.gfw.common.fullhalf;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Set;
@@ -77,6 +78,6 @@ public class FullHalfPairsBuilderTest {
     public void testSamePairIsIgnored() {
         Set<FullHalfPair> set = new FullHalfPairsBuilder().pair("ａ", "a").pair(
                 "ａ", "a").build().pairs();
-        assertThat(set.size(), is(1));
+        assertThat(set, hasSize(1));
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/AbstractConstraintsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/AbstractConstraintsTest.java
@@ -18,6 +18,7 @@ package org.terasoluna.gfw.common.validator.constraints;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Locale;
@@ -28,7 +29,6 @@ import javax.validation.Validation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
 
-import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 
 /**
@@ -59,10 +59,11 @@ abstract public class AbstractConstraintsTest<F> {
      */
     protected void assertFailedToInitialize(ValidationException ex,
             Class<? extends Throwable> causeType) {
-        assertThat(ex.getCause(), allOf(Matchers.<Throwable> instanceOf(
-                IllegalArgumentException.class), hasProperty("message", is(
-                        MESSAGE_INITIALIZE_ERROR)), hasProperty("cause",
-                                Matchers.<Throwable> instanceOf(causeType))));
+        assertThat(ex.getCause(), allOf( //
+                instanceOf(IllegalArgumentException.class), //
+                hasProperty("message", is(MESSAGE_INITIALIZE_ERROR)), //
+                hasProperty("cause", instanceOf(causeType)) //
+        ));
     }
 
     /**
@@ -73,11 +74,14 @@ abstract public class AbstractConstraintsTest<F> {
      */
     protected void assertFailedToInitialize(ValidationException ex,
             Class<? extends Throwable> causeType, String message) {
-        assertThat(ex.getCause(), allOf(Matchers.<Throwable> instanceOf(
-                IllegalArgumentException.class), hasProperty("message", is(
-                        MESSAGE_INITIALIZE_ERROR)), hasProperty("cause", allOf(
-                                Matchers.<Throwable> instanceOf(causeType),
-                                hasProperty("message", is(message))))));
+        assertThat(ex.getCause(), allOf( //
+                instanceOf(IllegalArgumentException.class), //
+                hasProperty("message", is(MESSAGE_INITIALIZE_ERROR)), //
+                hasProperty("cause", allOf( //
+                        instanceOf(causeType), //
+                        hasProperty("message", is(message)) //
+                )) //
+        ));
     }
 
     /**
@@ -86,10 +90,11 @@ abstract public class AbstractConstraintsTest<F> {
      * @param type expected not support type.
      */
     protected void assertTypeNotSupport(ValidationException ex, Class<?> type) {
-        assertThat(ex.getCause(), allOf(Matchers.<Throwable> instanceOf(
-                IllegalArgumentException.class), hasProperty("message", is(
-                        String.format(MESSAGE_NOTSUPPORT_ERROR, type
-                                .getName())))));
+        assertThat(ex.getCause(), allOf( //
+                instanceOf(IllegalArgumentException.class), //
+                hasProperty("message", is(String.format(
+                        MESSAGE_NOTSUPPORT_ERROR, type.getName()))) //
+        ));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMaxTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMaxTest.java
@@ -15,23 +15,21 @@
  */
 package org.terasoluna.gfw.common.validator.constraints;
 
-import static java.util.Comparator.comparing;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
-import javax.validation.ConstraintViolation;
 import javax.validation.UnexpectedTypeException;
-import javax.validation.Validation;
 import javax.validation.ValidationException;
-import javax.validation.Validator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +54,7 @@ public class ByteMaxTest extends AbstractConstraintsTest<ByteMaxTestForm> {
     public void testInputNull() {
 
         violations = validator.validate(form);
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     /**
@@ -69,16 +67,15 @@ public class ByteMaxTest extends AbstractConstraintsTest<ByteMaxTestForm> {
             form.setStringProperty("ああa");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 6)))));
         }
 
         {
             form.setStringProperty("ああ");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -92,16 +89,15 @@ public class ByteMaxTest extends AbstractConstraintsTest<ByteMaxTestForm> {
             form.setStringBuilderProperty(new StringBuilder("ああa"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 6)))));
         }
 
         {
             form.setStringBuilderProperty(new StringBuilder("ああ"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -115,16 +111,15 @@ public class ByteMaxTest extends AbstractConstraintsTest<ByteMaxTestForm> {
             form.setStringProperty("あああa");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 6)))));
         }
 
         {
             form.setStringProperty("あああ");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -162,90 +157,58 @@ public class ByteMaxTest extends AbstractConstraintsTest<ByteMaxTestForm> {
     }
 
     /**
-     * all values in the collection are valid.
+     * validate collection element values.
      */
     @Test
-    public void testCollectionValid() {
-        form.setListProperty(Arrays.asList("ああ", "ああ"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMaxTestForm>> violations = validator
-                .validate(form);
+    public void testElementTypeTypeUse() {
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
-    }
+        {
+            form.setListProperty(Arrays.asList("ああ", "ああ"));
 
-    /**
-     * first value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionFirstInvalid() {
-        form.setListProperty(Arrays.asList("ああa", "ああ"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMaxTestForm>> violations = validator
-                .validate(form);
+            violations = validator.validate(form);
+            assertThat(violations, is(empty()));
+        }
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+        {
+            form.setListProperty(Arrays.asList("ああa", "ああ"));
 
-        ConstraintViolation<ByteMaxTestForm> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "listProperty[0].<list element>"));
-        assertThat(v.getMessage(), is(String.format(MESSAGE_VALIDATION_ERROR,
-                6)));
-    }
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6))))));
+        }
 
-    /**
-     * last value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionLastInvalid() {
-        form.setListProperty(Arrays.asList("ああ", "ああa"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMaxTestForm>> violations = validator
-                .validate(form);
+        {
+            form.setListProperty(Arrays.asList("ああ", "ああa"));
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6))))));
+        }
 
-        ConstraintViolation<ByteMaxTestForm> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "listProperty[1].<list element>"));
-        assertThat(v.getMessage(), is(String.format(MESSAGE_VALIDATION_ERROR,
-                6)));
-    }
+        {
+            form.setListProperty(Arrays.asList("ああa", "ああa"));
 
-    /**
-     * all values in the collection are invalid.
-     */
-    @Test
-    public void testCollectionAllInvalid() {
-        form.setListProperty(Arrays.asList("ああa", "ああa"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMaxTestForm>> violations = validator
-                .validate(form);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(2));
-
-        Iterator<ConstraintViolation<ByteMaxTestForm>> iterator = violations
-                .stream().sorted(comparing(v -> v.getPropertyPath().toString()))
-                .iterator();
-
-        ConstraintViolation<ByteMaxTestForm> violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "listProperty[0].<list element>"));
-        assertThat(violation.getMessage(), is(String.format(
-                MESSAGE_VALIDATION_ERROR, 6)));
-        violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "listProperty[1].<list element>"));
-        assertThat(violation.getMessage(), is(String.format(
-                MESSAGE_VALIDATION_ERROR, 6)));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6)))), //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6))))));
+        }
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMinTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteMinTest.java
@@ -15,23 +15,21 @@
  */
 package org.terasoluna.gfw.common.validator.constraints;
 
-import static java.util.Comparator.comparing;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
-import javax.validation.ConstraintViolation;
 import javax.validation.UnexpectedTypeException;
-import javax.validation.Validation;
 import javax.validation.ValidationException;
-import javax.validation.Validator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +54,7 @@ public class ByteMinTest extends AbstractConstraintsTest<ByteMinTestForm> {
     public void testInputNull() {
 
         violations = validator.validate(form);
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     /**
@@ -69,16 +67,15 @@ public class ByteMinTest extends AbstractConstraintsTest<ByteMinTestForm> {
             form.setStringProperty("あaa");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 6)))));
         }
 
         {
             form.setStringProperty("ああ");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -92,16 +89,15 @@ public class ByteMinTest extends AbstractConstraintsTest<ByteMinTestForm> {
             form.setStringBuilderProperty(new StringBuilder("あaa"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 6)))));
         }
 
         {
             form.setStringBuilderProperty(new StringBuilder("ああ"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -115,16 +111,15 @@ public class ByteMinTest extends AbstractConstraintsTest<ByteMinTestForm> {
             form.setStringProperty("ああa");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 6)))));
         }
 
         {
             form.setStringProperty("あああ");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -162,90 +157,58 @@ public class ByteMinTest extends AbstractConstraintsTest<ByteMinTestForm> {
     }
 
     /**
-     * all values in the collection are valid.
+     * validate collection element values.
      */
     @Test
-    public void testCollectionValid() {
-        form.setListProperty(Arrays.asList("ああ", "ああ"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMinTestForm>> violations = validator
-                .validate(form);
+    public void testElementTypeTypeUse() {
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
-    }
+        {
+            form.setListProperty(Arrays.asList("ああ", "ああ"));
 
-    /**
-     * first value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionFirstInvalid() {
-        form.setListProperty(Arrays.asList("あaa", "ああ"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMinTestForm>> violations = validator
-                .validate(form);
+            violations = validator.validate(form);
+            assertThat(violations, is(empty()));
+        }
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+        {
+            form.setListProperty(Arrays.asList("あaa", "ああ"));
 
-        ConstraintViolation<ByteMinTestForm> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "listProperty[0].<list element>"));
-        assertThat(v.getMessage(), is(String.format(MESSAGE_VALIDATION_ERROR,
-                6)));
-    }
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6))))));
+        }
 
-    /**
-     * last value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionLastInvalid() {
-        form.setListProperty(Arrays.asList("ああ", "あaa"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMinTestForm>> violations = validator
-                .validate(form);
+        {
+            form.setListProperty(Arrays.asList("ああ", "あaa"));
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6))))));
+        }
 
-        ConstraintViolation<ByteMinTestForm> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "listProperty[1].<list element>"));
-        assertThat(v.getMessage(), is(String.format(MESSAGE_VALIDATION_ERROR,
-                6)));
-    }
+        {
+            form.setListProperty(Arrays.asList("あaa", "あaa"));
 
-    /**
-     * all values in the collection are invalid.
-     */
-    @Test
-    public void testCollectionAllInvalid() {
-        form.setListProperty(Arrays.asList("あaa", "あaa"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteMinTestForm>> violations = validator
-                .validate(form);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(2));
-
-        Iterator<ConstraintViolation<ByteMinTestForm>> iterator = violations
-                .stream().sorted(comparing(v -> v.getPropertyPath().toString()))
-                .iterator();
-
-        ConstraintViolation<ByteMinTestForm> violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "listProperty[0].<list element>"));
-        assertThat(violation.getMessage(), is(String.format(
-                MESSAGE_VALIDATION_ERROR, 6)));
-        violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "listProperty[1].<list element>"));
-        assertThat(violation.getMessage(), is(String.format(
-                MESSAGE_VALIDATION_ERROR, 6)));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6)))), //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 6))))));
+        }
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteSizeTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteSizeTest.java
@@ -15,23 +15,21 @@
  */
 package org.terasoluna.gfw.common.validator.constraints;
 
-import static java.util.Comparator.comparing;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
-import javax.validation.ConstraintViolation;
 import javax.validation.UnexpectedTypeException;
-import javax.validation.Validation;
 import javax.validation.ValidationException;
-import javax.validation.Validator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +54,7 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
     public void testInputNull() {
 
         violations = validator.validate(form);
-        assertThat(violations.size(), is(0));
+        assertThat(violations, is(empty()));
     }
 
     /**
@@ -69,32 +67,30 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
             form.setStringProperty("aa");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 6)))));
         }
 
         {
             form.setStringProperty("あ");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringProperty("ああ");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringProperty("ああa");
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 6)))));
         }
     }
 
@@ -108,32 +104,30 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
             form.setStringBuilderProperty(new StringBuilder("aa"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 6)))));
         }
 
         {
             form.setStringBuilderProperty(new StringBuilder("あ"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringBuilderProperty(new StringBuilder("ああ"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringBuilderProperty(new StringBuilder("ああa"));
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 6)))));
         }
     }
 
@@ -147,32 +141,30 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
             form.setStringProperty("あ");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 6)))));
         }
 
         {
             form.setStringProperty("あa");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringProperty("あああ");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringProperty("あああa");
 
             violations = validator.validate(form, SpecifyCharset.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 6)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 6)))));
         }
     }
 
@@ -197,7 +189,7 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
             form.setStringProperty("");
 
             violations = validator.validate(form, NotSpecifyMinAndMax.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -205,7 +197,7 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
                     0));
 
             violations = validator.validate(form, NotSpecifyMinAndMax.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -245,25 +237,23 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
             form.setStringProperty("aa");
 
             violations = validator.validate(form, MaxEqualsToMin.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 3)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 3)))));
         }
 
         {
             form.setStringProperty("あ");
 
             violations = validator.validate(form, MaxEqualsToMin.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
             form.setStringProperty("あa");
 
             violations = validator.validate(form, MaxEqualsToMin.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, 3, 3)));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, 3, 3)))));
         }
     }
 
@@ -290,90 +280,58 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
     }
 
     /**
-     * all values in the collection are valid.
+     * validate collection element values.
      */
     @Test
-    public void testCollectionValid() {
-        form.setListProperty(Arrays.asList("あ", "ああ"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteSizeTestForm>> violations = validator
-                .validate(form);
+    public void testElementTypeTypeUse() {
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(0));
-    }
+        {
+            form.setListProperty(Arrays.asList("あ", "ああ"));
 
-    /**
-     * first value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionFirstInvalid() {
-        form.setListProperty(Arrays.asList("aa", "あ"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteSizeTestForm>> violations = validator
-                .validate(form);
+            violations = validator.validate(form);
+            assertThat(violations, is(empty()));
+        }
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+        {
+            form.setListProperty(Arrays.asList("aa", "あ"));
 
-        ConstraintViolation<ByteSizeTestForm> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "listProperty[0].<list element>"));
-        assertThat(v.getMessage(), is(String.format(MESSAGE_VALIDATION_ERROR, 3,
-                6)));
-    }
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 3, 6))))));
+        }
 
-    /**
-     * last value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionLastInvalid() {
-        form.setListProperty(Arrays.asList("ああ", "ああa"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteSizeTestForm>> violations = validator
-                .validate(form);
+        {
+            form.setListProperty(Arrays.asList("ああ", "ああa"));
 
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(1));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 3, 6))))));
+        }
 
-        ConstraintViolation<ByteSizeTestForm> v = violations.iterator().next();
-        assertThat(v.getPropertyPath().toString(), is(
-                "listProperty[1].<list element>"));
-        assertThat(v.getMessage(), is(String.format(MESSAGE_VALIDATION_ERROR, 3,
-                6)));
-    }
+        {
+            form.setListProperty(Arrays.asList("aa", "ああa"));
 
-    /**
-     * all values in the collection are invalid.
-     */
-    @Test
-    public void testCollectionAllInvalid() {
-        form.setListProperty(Arrays.asList("aa", "ああa"));
-        Validator validator = Validation.buildDefaultValidatorFactory()
-                .getValidator();
-        Set<ConstraintViolation<ByteSizeTestForm>> violations = validator
-                .validate(form);
-
-        assertThat(violations, is(notNullValue()));
-        assertThat(violations.size(), is(2));
-
-        Iterator<ConstraintViolation<ByteSizeTestForm>> iterator = violations
-                .stream().sorted(comparing(v -> v.getPropertyPath().toString()))
-                .iterator();
-
-        ConstraintViolation<ByteSizeTestForm> violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "listProperty[0].<list element>"));
-        assertThat(violation.getMessage(), is(String.format(
-                MESSAGE_VALIDATION_ERROR, 3, 6)));
-        violation = iterator.next();
-        assertThat(violation.getPropertyPath().toString(), is(
-                "listProperty[1].<list element>"));
-        assertThat(violation.getMessage(), is(String.format(
-                MESSAGE_VALIDATION_ERROR, 3, 6)));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 3, 6)))), //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, 3, 6))))));
+        }
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
@@ -17,21 +17,18 @@ package org.terasoluna.gfw.common.validator.constraints;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasToString;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThrows;
 
 import java.beans.IntrospectionException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Path.PropertyNode;
 import javax.validation.ValidationException;
 
 import org.junit.Before;
@@ -63,7 +60,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setLeft(100);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -71,7 +68,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -79,7 +76,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(null);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -95,9 +92,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(99);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -105,7 +102,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -121,9 +118,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, LessThanOrEqual.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -131,7 +128,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, LessThanOrEqual.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -139,7 +136,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, LessThanOrEqual.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -155,9 +152,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, LessThan.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -165,9 +162,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, LessThan.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -175,7 +172,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, LessThan.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -191,9 +188,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -201,7 +198,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -209,9 +206,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
     }
 
@@ -227,7 +224,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, NotEqual.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -235,9 +232,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, NotEqual.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -245,7 +242,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, NotEqual.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
     }
@@ -262,9 +259,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, GreaterThan.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -272,9 +269,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, GreaterThan.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -282,7 +279,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, GreaterThan.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -298,9 +295,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, GreaterThanOrEqual.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left", "right")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "right")))));
         }
 
         {
@@ -308,7 +305,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, GreaterThanOrEqual.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -316,7 +313,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, GreaterThanOrEqual.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -332,7 +329,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, RequireBoth.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -340,16 +337,12 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(null);
 
             violations = validator.validate(form, RequireBoth.class);
-            assertThat(violations.size(), is(1));
-            for (ConstraintViolation<CompareTestForm> violation : violations) {
-                assertThat(violation.getMessage(), is(String.format(
-                        MESSAGE_VALIDATION_ERROR, "left", "right")));
-                for (javax.validation.Path.Node node : violation
-                        .getPropertyPath()) {
-                    assertThat(node, instanceOf(PropertyNode.class));
-                    assertThat(node.getName(), is("left"));
-                }
-            }
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString("left")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, "left",
+                                    "right"))))));
         }
 
         {
@@ -357,16 +350,12 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, RequireBoth.class);
-            assertThat(violations.size(), is(1));
-            for (ConstraintViolation<CompareTestForm> violation : violations) {
-                assertThat(violation.getMessage(), is(String.format(
-                        MESSAGE_VALIDATION_ERROR, "left", "right")));
-                for (javax.validation.Path.Node node : violation
-                        .getPropertyPath()) {
-                    assertThat(node, instanceOf(PropertyNode.class));
-                    assertThat(node.getName(), is("left"));
-                }
-            }
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString("left")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, "left",
+                                    "right"))))));
         }
 
         {
@@ -374,7 +363,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(null);
 
             violations = validator.validate(form, RequireBoth.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -390,7 +379,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, RequireEither.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -398,7 +387,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(null);
 
             violations = validator.validate(form, RequireEither.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -406,7 +395,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(100);
 
             violations = validator.validate(form, RequireEither.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
 
         {
@@ -414,7 +403,7 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setRight(null);
 
             violations = validator.validate(form, RequireEither.class);
-            assertThat(violations.size(), is(0));
+            assertThat(violations, is(empty()));
         }
     }
 
@@ -429,16 +418,11 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         form.setRight(99);
 
         violations = validator.validate(form, NodeProperty.class);
-        assertThat(violations.size(), is(1));
-        for (ConstraintViolation<CompareTestForm> violation : violations) {
-            assertThat(violation.getMessage(), is(String.format(
-                    MESSAGE_VALIDATION_ERROR, "left", "right")));
-            for (javax.validation.Path.Node node : violation
-                    .getPropertyPath()) {
-                assertThat(node, instanceOf(PropertyNode.class));
-                assertThat(node.getName(), is("left"));
-            }
-        }
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString("left")), //
+                        hasProperty("message", is(String.format(
+                                MESSAGE_VALIDATION_ERROR, "left", "right"))))));
     }
 
     /**
@@ -452,16 +436,11 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         form.setRight(99);
 
         violations = validator.validate(form, PathRootBean.class);
-        assertThat(violations.size(), is(1));
-        for (ConstraintViolation<CompareTestForm> violation : violations) {
-            assertThat(violation.getMessage(), is(String.format(
-                    MESSAGE_VALIDATION_ERROR, "left", "right")));
-            for (javax.validation.Path.Node node : violation
-                    .getPropertyPath()) {
-                assertThat(node, instanceOf(PropertyNode.class));
-                assertThat(node.getName(), nullValue());
-            }
-        }
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(emptyString())), //
+                        hasProperty("message", is(String.format(
+                                MESSAGE_VALIDATION_ERROR, "left", "right"))))));
     }
 
     /**
@@ -476,10 +455,9 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
             form.setStringProperty("100");
 
             violations = validator.validate(form, TypeUnmatch.class);
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next().getMessage(), is(String
-                    .format(MESSAGE_VALIDATION_ERROR, "left",
-                            "stringProperty")));
+            assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                    String.format(MESSAGE_VALIDATION_ERROR, "left",
+                            "stringProperty")))));
         }
     }
 
@@ -523,72 +501,67 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
     }
 
     /**
-     * all values in the collection are valid.
+     * validate collection element values.
      */
     @Test
-    public void testCollectionValid() {
-        form.setListProperty(Arrays.asList(new Pair(100, 100),
-                new Pair(100, 100)));
+    public void testElementTypeTypeUse() {
 
-        violations = validator.validate(form);
-        assertThat(violations.size(), is(0));
-    }
+        {
+            form.setListProperty(Arrays.asList(new Pair(100, 100),
+                    new Pair(100, 100)));
 
-    /**
-     * first value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionFirstInvalid() {
-        form.setListProperty(Arrays.asList(new Pair(101, 100),
-                new Pair(100, 100)));
+            violations = validator.validate(form);
+            assertThat(violations, is(empty()));
+        }
 
-        violations = validator.validate(form);
-        assertThat(violations.size(), is(1));
-        assertThat(violations, contains(allOf( //
-                hasProperty("propertyPath", hasToString(
-                        "listProperty[0].<list element>.left")), //
-                hasProperty("message", is(String.format(
-                        MESSAGE_VALIDATION_ERROR, "left", "right"))))));
-    }
+        {
+            form.setListProperty(Arrays.asList(new Pair(101, 100),
+                    new Pair(100, 100)));
 
-    /**
-     * last value in the collection is invalid.
-     */
-    @Test
-    public void testCollectionLastInvalid() {
-        form.setListProperty(Arrays.asList(new Pair(100, 100),
-                new Pair(100, 101)));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>.left")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, "left",
+                                    "right"))))));
+        }
 
-        violations = validator.validate(form);
-        assertThat(violations.size(), is(1));
-        assertThat(violations, contains(allOf( //
-                hasProperty("propertyPath", hasToString(
-                        "listProperty[1].<list element>.left")), //
-                hasProperty("message", is(String.format(
-                        MESSAGE_VALIDATION_ERROR, "left", "right"))))));
-    }
+        {
+            form.setListProperty(Arrays.asList(new Pair(100, 100),
+                    new Pair(100, 101)));
 
-    /**
-     * all values in the collection are invalid.
-     */
-    @Test
-    public void testCollectionAllInvalid() {
-        form.setListProperty(Arrays.asList(new Pair(101, 100),
-                new Pair(100, 101)));
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>.left")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, "left",
+                                    "right"))))));
+        }
 
-        violations = validator.validate(form);
-        assertThat(violations.size(), is(2));
-        assertThat(violations, containsInAnyOrder( //
-                allOf( //
-                        hasProperty("propertyPath", hasToString(
-                                "listProperty[0].<list element>.left")), //
-                        hasProperty("message", is(String.format(
-                                MESSAGE_VALIDATION_ERROR, "left", "right")))), //
-                allOf( //
-                        hasProperty("propertyPath", hasToString(
-                                "listProperty[1].<list element>.left")), //
-                        hasProperty("message", is(String.format(
-                                MESSAGE_VALIDATION_ERROR, "left", "right"))))));
+        {
+            form.setListProperty(Arrays.asList(new Pair(101, 100),
+                    new Pair(100, 101)));
+
+            violations = validator.validate(form);
+            assertThat(violations, containsInAnyOrder( //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[0].<list element>.left")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, "left",
+                                    "right")))), allOf( //
+                                            hasProperty("propertyPath",
+                                                    hasToString(
+                                                            "listProperty[1].<list element>.left")), //
+                                            hasProperty("message", is(String
+                                                    .format(MESSAGE_VALIDATION_ERROR,
+                                                            "left",
+                                                            "right"))))));
+        }
     }
 
     /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
@@ -553,14 +553,13 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
                                     "listProperty[0].<list element>.left")), //
                             hasProperty("message", is(String.format(
                                     MESSAGE_VALIDATION_ERROR, "left",
-                                    "right")))), allOf( //
-                                            hasProperty("propertyPath",
-                                                    hasToString(
-                                                            "listProperty[1].<list element>.left")), //
-                                            hasProperty("message", is(String
-                                                    .format(MESSAGE_VALIDATION_ERROR,
-                                                            "left",
-                                                            "right"))))));
+                                    "right")))), //
+                    allOf( //
+                            hasProperty("propertyPath", hasToString(
+                                    "listProperty[1].<list element>.left")), //
+                            hasProperty("message", is(String.format(
+                                    MESSAGE_VALIDATION_ERROR, "left",
+                                    "right"))))));
         }
     }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ContributorValidationMessagesJaTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ContributorValidationMessagesJaTest.java
@@ -1,6 +1,8 @@
 package org.terasoluna.gfw.common.validator.constraints;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Locale;
@@ -41,9 +43,8 @@ public class ContributorValidationMessagesJaTest {
 
         Set<ConstraintViolation<ByteMinTestForm>> violations = validator
                 .validate(form);
-        assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is(String.format(
-                "%d バイト以上のサイズにしてください", 6)));
+        assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                String.format("%d バイト以上のサイズにしてください", 6)))));
     }
 
     /**
@@ -57,9 +58,8 @@ public class ContributorValidationMessagesJaTest {
 
         Set<ConstraintViolation<ByteMaxTestForm>> violations = validator
                 .validate(form);
-        assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is(String.format(
-                "%d バイト以下のサイズにしてください", 6)));
+        assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                String.format("%d バイト以下のサイズにしてください", 6)))));
     }
 
     /**
@@ -73,9 +73,8 @@ public class ContributorValidationMessagesJaTest {
 
         Set<ConstraintViolation<ByteSizeTestForm>> violations = validator
                 .validate(form);
-        assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is(String.format(
-                "%d から %d バイトの間のサイズにしてください", 3, 6)));
+        assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                String.format("%d から %d バイトの間のサイズにしてください", 3, 6)))));
     }
 
     /**
@@ -90,9 +89,8 @@ public class ContributorValidationMessagesJaTest {
 
         Set<ConstraintViolation<CompareTestForm>> violations = validator
                 .validate(form);
-        assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is(String.format(
-                "正しくない %s と %s の組合せです", "left", "right")));
+        assertThat(violations, containsInAnyOrder(hasProperty("message", is(
+                String.format("正しくない %s と %s の組合せです", "left", "right")))));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -18,7 +18,6 @@ package org.terasoluna.gfw.web.pagination;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +29,7 @@ import javax.servlet.jsp.tagext.TagSupport;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.core.serializer.support.SerializationFailedException;
+import org.junit.Test.None;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -43,7 +42,6 @@ import org.springframework.util.SerializationUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.tags.form.TagWriter;
 
-@SuppressWarnings("unchecked")
 public class PaginationTagTest {
 
     protected StringWriter writer;
@@ -51,6 +49,8 @@ public class PaginationTagTest {
     protected MockPageContext pageContext;
 
     protected PaginationTag tag;
+
+    Page<String> page;
 
     protected MockPageContext createPageContext() {
         MockServletContext sc = new MockServletContext();
@@ -64,7 +64,7 @@ public class PaginationTagTest {
         return new MockPageContext(sc, request, response);
     }
 
-    @SuppressWarnings("serial")
+    @SuppressWarnings({ "serial", "unchecked" })
     @Before
     public void setUp() throws Exception {
         this.writer = new StringWriter();
@@ -76,6 +76,7 @@ public class PaginationTagTest {
             }
         };
         tag.setPageContext(pageContext);
+        this.page = mock(Page.class);
     }
 
     @After
@@ -135,7 +136,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal01() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -164,7 +164,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal02() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(1);
         when(page.getSize()).thenReturn(10);
@@ -193,7 +192,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal03() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(5);
         when(page.getSize()).thenReturn(10);
@@ -222,7 +220,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal04() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -251,7 +248,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal05() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(95);
         when(page.getSize()).thenReturn(10);
@@ -280,7 +276,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal06() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(99);
         when(page.getSize()).thenReturn(10);
@@ -309,7 +304,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal07() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(100);
         when(page.getSize()).thenReturn(10);
@@ -335,7 +329,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal08() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -382,7 +375,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal10() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -411,7 +403,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal11() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -441,7 +432,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal12() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -473,7 +463,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal13() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -503,7 +492,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal14() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -533,7 +521,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal15() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -566,7 +553,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal16() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(20);
         when(page.getSize()).thenReturn(10);
@@ -598,7 +584,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal17() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -629,7 +614,6 @@ public class PaginationTagTest {
     @Test
     public void testDoStartTagInternal17_2() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(99);
         when(page.getSize()).thenReturn(10);
@@ -651,7 +635,7 @@ public class PaginationTagTest {
 
     @Test
     public void testDoStartTagInternal_disabledHref_is_empty() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -670,7 +654,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue12_testDoStartTagInternal_criteriaQuery_specified() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -712,7 +696,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue12_testDoStartTagInternal_criteriaQuery_specified_startWith_questionMark() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -753,7 +737,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue12_testDoStartTagInternal_disableHtmlEscapeOfCriteriaQuery_specified_true() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -794,7 +778,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue12_testDoStartTagInternal_criteriaQuery_specified_queryImpl_notSpecified() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -831,7 +815,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue13_14_testDoStartTagInternal_linkOfCurrentPage_specified_true() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -869,7 +853,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue13_14_testDoStartTagInternal_linkOfCurrentPage_specified_false() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -907,7 +891,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue13_14_testDoStartTagInternal_linkOfCurrentPage_isEmpty() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -945,7 +929,7 @@ public class PaginationTagTest {
 
     @Test
     public void issue12_testDoStartTagInternal_criteriaQuery_specified_startWith_andMark() throws Exception {
-        Page<String> page = mock(Page.class);
+
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(10);
@@ -983,36 +967,26 @@ public class PaginationTagTest {
         assertThat(getOutput(), is(expected.toString()));
     }
 
-    @Test
-    public void testSetters() {
+    @Test(expected = None.class)
+    public void testSetters() throws Exception {
 
         PaginationTag tag1 = new PaginationTag();
         tag1.setPageContext(pageContext);
 
-        try {
-            // Just for ensuring coverage
-            tag1.createTagWriter();
-            tag1.setPreviousLinkText("");
-            tag1.setNextLinkText("");
-            tag1.setDisabledHref("");
-            tag1.setActiveClass("");
-            tag1.setDisabledClass("");
-            tag1.setEnableLinkOfCurrentPage("");
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            fail();
-        }
+        // Just for ensuring coverage
+        tag1.createTagWriter();
+        tag1.setPreviousLinkText("");
+        tag1.setNextLinkText("");
+        tag1.setDisabledHref("");
+        tag1.setActiveClass("");
+        tag1.setDisabledClass("");
+        tag1.setEnableLinkOfCurrentPage("");
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testSerialization() {
-        try {
-            byte[] serialized = SerializationUtils.serialize(
-                    new PaginationTag());
-            SerializationUtils.deserialize(serialized);
-        } catch (SerializationFailedException e) {
-            fail();
-        }
+        byte[] serialized = SerializationUtils.serialize(new PaginationTag());
+        SerializationUtils.deserialize(serialized);
     }
 
     /**
@@ -1033,7 +1007,6 @@ public class PaginationTagTest {
     @Test
     public void testEndOuterElement() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(0);
         when(page.getSize()).thenReturn(0);
@@ -1056,7 +1029,6 @@ public class PaginationTagTest {
     @Test
     public void testEndOuterElement2() throws Exception {
 
-        Page<String> page = mock(Page.class);
         // set mock behavior
         when(page.getNumber()).thenReturn(1);
         when(page.getSize()).thenReturn(0);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenTagTest.java
@@ -17,7 +17,9 @@ package org.terasoluna.gfw.web.token.transaction;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.hasLength;
+import static org.hamcrest.Matchers.hasToString;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -41,7 +43,7 @@ public class TransactionTokenTagTest {
      * TransactionToken is null
      */
     @Test
-    public void testWriteTagContentTagWriter01() {
+    public void testWriteTagContentTagWriter01() throws Exception {
 
         // setup arguments
         TransactionTokenTag tag = new TransactionTokenTag();
@@ -58,15 +60,10 @@ public class TransactionTokenTagTest {
                         .thenReturn(null);
 
         // run
-        int result = 1;
-        try {
-            result = tag.writeTagContent(tagWriter);
-        } catch (JspException e) {
-            fail();
-        }
+        int result = tag.writeTagContent(tagWriter);
 
         // assert
-        assertThat(sw.getBuffer().toString(), is(""));
+        assertThat(sw.getBuffer(), hasLength(0));
         assertThat(result, is(0));
     }
 
@@ -74,7 +71,7 @@ public class TransactionTokenTagTest {
      * TransactionToken is not null
      */
     @Test
-    public void testWriteTagContentTagWriter02() {
+    public void testWriteTagContentTagWriter02() throws Exception {
 
         // setup arguments
         TransactionTokenTag tag = new TransactionTokenTag();
@@ -92,12 +89,7 @@ public class TransactionTokenTagTest {
                         .thenReturn(token);
 
         // run
-        int result = 1;
-        try {
-            result = tag.writeTagContent(tagWriter);
-        } catch (JspException e) {
-            fail();
-        }
+        int result = tag.writeTagContent(tagWriter);
 
         // capture
         String expected = "<input type=\"hidden\" name=\""
@@ -105,7 +97,7 @@ public class TransactionTokenTagTest {
                 + "\" value=\"" + token.getTokenString() + "\"/>";
 
         // assert
-        assertThat(sw.getBuffer().toString(), is(expected));
+        assertThat(sw.getBuffer(), hasToString(expected));
         assertThat(result, is(0));
     }
 
@@ -130,13 +122,9 @@ public class TransactionTokenTagTest {
                         .thenReturn(token);
 
         // run
-        int result = 1;
-        try {
+        assertThrows(JspException.class, () -> {
             doThrow(new JspException()).when(tagWriter).startTag(anyString());
-            result = tag.writeTagContent(tagWriter);
-        } catch (JspException e) {
-            e.printStackTrace();
-        }
-        assertThat(result, is(1));
+            tag.writeTagContent(tagWriter);
+        });
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/util/JspTagUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/util/JspTagUtilsTest.java
@@ -18,7 +18,7 @@ package org.terasoluna.gfw.web.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 import java.lang.reflect.Constructor;
 
@@ -65,19 +65,17 @@ public class JspTagUtilsTest {
 
     @Test
     public void toBoolean_valueIsNotTrueOrFalse() throws JspException {
-        try {
+
+        JspTagException e = assertThrows(JspTagException.class, () -> {
             JspTagUtils.toBoolean("on", true, "field1");
-            fail("should be occurred JspTagException.");
-        } catch (JspTagException e) {
-            assertThat(e.getMessage(), is(
-                    "The value of field1 must be either true or false."));
-        }
-        try {
+        });
+        assertThat(e.getMessage(), is(
+                "The value of field1 must be either true or false."));
+
+        e = assertThrows(JspTagException.class, () -> {
             JspTagUtils.toBoolean("off", false, "field2");
-            fail("should be occurred JspTagException.");
-        } catch (JspTagException e) {
-            assertThat(e.getMessage(), is(
-                    "The value of field2 must be either true or false."));
-        }
+        });
+        assertThat(e.getMessage(), is(
+                "The value of field2 must be either true or false."));
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/codelist/CodeListInterceptorTest.java
@@ -17,13 +17,14 @@ package org.terasoluna.gfw.web.codelist;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThrows;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -138,8 +139,8 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         assertThat(actualAttributeNames.hasMoreElements(), is(true));
         actualAttributeNames.nextElement();
         assertThat(actualAttributeNames.hasMoreElements(), is(false));
-        assertThat(mockRequest.getAttribute("simpleMapCodeList").toString(), is(
-                simpleMapCodeList.asMap().toString()));
+        assertThat(mockRequest.getAttribute("simpleMapCodeList"), is(
+                simpleMapCodeList.asMap()));
 
     }
 
@@ -172,10 +173,10 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
                 "C_simpleMapCodeList", SimpleMapCodeList.class);
         SimpleI18nCodeList simpleI18nCodeList = getApplicationContext().getBean(
                 "C_simpleI18nCodeList", SimpleI18nCodeList.class);
-        assertThat(mockRequest.getAttribute("C_simpleMapCodeList").toString(),
-                is(simpleMapCodeList.asMap().toString()));
-        assertThat(mockRequest.getAttribute("C_simpleI18nCodeList").toString(),
-                is(simpleI18nCodeList.asMap(Locale.ENGLISH).toString()));
+        assertThat(mockRequest.getAttribute("C_simpleMapCodeList"), is(
+                simpleMapCodeList.asMap()));
+        assertThat(mockRequest.getAttribute("C_simpleI18nCodeList"), is(
+                simpleI18nCodeList.asMap(Locale.ENGLISH)));
 
     }
 
@@ -228,8 +229,8 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         Map<String, CodeList> expectedCodeListMap = new HashMap<String, CodeList>(getApplicationContext()
                 .getBeansOfType(CodeList.class));
 
-        assertThat(testTarget.getCodeLists().toString(), is(expectedCodeListMap
-                .values().toString()));
+        assertThat(testTarget.getCodeLists(), contains(expectedCodeListMap
+                .values().toArray()));
 
     }
 
@@ -282,7 +283,7 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         testTarget.afterPropertiesSet();
 
         // do assert.
-        assertThat(testTarget.getCodeLists().isEmpty(), is(true));
+        assertThat(testTarget.getCodeLists(), is(empty()));
 
     }
 
@@ -310,7 +311,7 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         testTarget.afterPropertiesSet();
 
         // do assert.
-        assertThat(testTarget.getCodeLists().isEmpty(), is(true));
+        assertThat(testTarget.getCodeLists(), is(empty()));
         assertThat(logger.isDebugEnabled(), is(false));
 
         // init log level.
@@ -341,12 +342,10 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         testTarget.afterPropertiesSet();
 
         // do assert.
-        List<CodeList> expectedCodeLists = new ArrayList<CodeList>();
-        expectedCodeLists.add(mockApplicationContext.getBean(
-                "simpleMapCodeList", CodeList.class));
+        CodeList expectedCodeList = mockApplicationContext.getBean(
+                "simpleMapCodeList", CodeList.class);
 
-        assertThat(testTarget.getCodeLists().toString(), is(expectedCodeLists
-                .toString()));
+        assertThat(testTarget.getCodeLists(), contains(expectedCodeList));
 
     }
 
@@ -367,12 +366,12 @@ public class CodeListInterceptorTest extends ApplicationObjectSupport {
         testTarget.setApplicationContext(null);
 
         // do test.
-        try {
-            testTarget.afterPropertiesSet();
-        } catch (IllegalArgumentException e) {
-            // do assert.
-            assertThat("applicationContext is null.", is(e.getMessage()));
-        }
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    testTarget.afterPropertiesSet();
+                });
+        // do assert.
+        assertThat(e.getMessage(), is("applicationContext is null."));
 
     }
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/download/FileDownloadViewTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/download/FileDownloadViewTest.java
@@ -17,7 +17,7 @@ package org.terasoluna.gfw.web.download;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -113,78 +114,63 @@ public class FileDownloadViewTest {
         fileDownloadView.renderMergedOutputModel(model, request, response);
     }
 
-    @Test
-    public void testWriteResponseStreamWithBothStreamsNull() {
-        try {
-            fileDownloadView.writeResponseStream(null, null);
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail();
-        }
+    @Test(expected = None.class)
+    public void testWriteResponseStreamWithBothStreamsNull() throws Exception {
+        fileDownloadView.writeResponseStream(null, null);
+    }
+
+    @Test(expected = None.class)
+    public void testWriteResponseStreamWithNullOutputStream() throws Exception {
+        fileDownloadView.writeResponseStream(inputStream, null);
+    }
+
+    @Test(expected = None.class)
+    public void testSetChunkSize() throws Exception {
+        fileDownloadView.setChunkSize(512);
     }
 
     @Test
-    public void testWriteResponseStreamWithNullOutputStream() {
-        try {
-            fileDownloadView.writeResponseStream(inputStream, null);
-        } catch (IOException e) {
-            e.printStackTrace();
-            fail();
-        }
-    }
-
-    @Test
-    public void testSetChunkSize() {
-        try {
-            fileDownloadView.setChunkSize(512);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail();
-        }
-    }
-
-    @Test(expected = IOException.class)
-    public void testOutputStreamException() throws IOException {
+    public void testOutputStreamException() {
         // Set Mock Behavior
         response = mock(HttpServletResponse.class);
-        when(response.getOutputStream()).thenThrow(new IOException());
-        fileDownloadView.renderMergedOutputModel(model, request, response);
+
+        assertThrows(IOException.class, () -> {
+            when(response.getOutputStream()).thenThrow(new IOException());
+            fileDownloadView.renderMergedOutputModel(model, request, response);
+        });
     }
 
     @Test
-    public void testAfterPropertiesSet_chunkSize_is0() throws IOException {
+    public void testAfterPropertiesSet_chunkSize_is0() {
         // Set Mock Behavior
         fileDownloadView.setChunkSize(0);
-        try {
-            fileDownloadView.afterPropertiesSet();
-            fail("must occur IllegalArgumentException.");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is(
-                    "chunkSize must be over 1. specified chunkSize is \"0\"."));
-        }
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    fileDownloadView.afterPropertiesSet();
+                });
+        assertThat(e.getMessage(), is(
+                "chunkSize must be over 1. specified chunkSize is \"0\"."));
     }
 
     @Test
-    public void testAfterPropertiesSet_chunkSize_isNegative1() throws IOException {
+    public void testAfterPropertiesSet_chunkSize_isNegative1() {
         // Set Mock Behavior
         fileDownloadView.setChunkSize(-1);
-        try {
-            fileDownloadView.afterPropertiesSet();
-            fail("must occur IllegalArgumentException.");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is(
-                    "chunkSize must be over 1. specified chunkSize is \"-1\"."));
-        }
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    fileDownloadView.afterPropertiesSet();
+                });
+        assertThat(e.getMessage(), is(
+                "chunkSize must be over 1. specified chunkSize is \"-1\"."));
     }
 
-    @Test
-    public void testAfterPropertiesSet_chunkSize_is1() throws IOException {
+    @Test(expected = None.class)
+    public void testAfterPropertiesSet_chunkSize_is1() {
         // Set Mock Behavior
         fileDownloadView.setChunkSize(1);
-        try {
-            fileDownloadView.afterPropertiesSet();
-        } catch (IllegalArgumentException e) {
-            fail("must not occur IllegalArgumentException.");
-        }
+
+        fileDownloadView.afterPropertiesSet();
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/ObjectToMapConverterTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/ObjectToMapConverterTest.java
@@ -16,7 +16,9 @@
 package org.terasoluna.gfw.web.el;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -41,7 +43,7 @@ public class ObjectToMapConverterTest {
     public void testConvert0_SimpleJavaBean() throws Exception {
         Map<String, String> map = converter.convert(
                 new SearchUserForm0("yamada", 20));
-        assertThat(map.size(), is(2));
+        assertThat(map, aMapWithSize(2));
         assertThat(map, hasEntry("name", "yamada"));
         assertThat(map, hasEntry("age", "20"));
 
@@ -57,7 +59,7 @@ public class ObjectToMapConverterTest {
     public void testConvert0_With_Prefix() throws Exception {
         Map<String, String> map = converter.convert("pre",
                 new SearchUserForm0("yamada", 20));
-        assertThat(map.size(), is(2));
+        assertThat(map, aMapWithSize(2));
         assertThat(map, hasEntry("pre.name", "yamada"));
         assertThat(map, hasEntry("pre.age", "20"));
     }
@@ -66,7 +68,7 @@ public class ObjectToMapConverterTest {
     public void testConvert1_NestedJavaBean() throws Exception {
         Map<String, String> map = converter.convert(
                 new SearchUserForm1(new SearchUserCriteriaForm1("yamada", 20), true));
-        assertThat(map.size(), is(3));
+        assertThat(map, aMapWithSize(3));
         assertThat(map, hasEntry("criteria.name", "yamada"));
         assertThat(map, hasEntry("criteria.age", "20"));
         assertThat(map, hasEntry("rememberCriteria", "true"));
@@ -87,7 +89,7 @@ public class ObjectToMapConverterTest {
                 new BatchUpdateUserForm2(Arrays.asList(
                         new UpdateUserCriteriaForm2("yamada", 20),
                         new UpdateUserCriteriaForm2("tanaka", 50)), LogicalOperator2.AND));
-        assertThat(map.size(), is(5));
+        assertThat(map, aMapWithSize(5));
         assertThat(map, hasEntry("criteria[0].name", "yamada"));
         assertThat(map, hasEntry("criteria[0].age", "20"));
         assertThat(map, hasEntry("criteria[1].name", "tanaka"));
@@ -99,7 +101,7 @@ public class ObjectToMapConverterTest {
         WebDataBinder binder = new WebDataBinder(form);
         binder.bind(new MutablePropertyValues(map));
         assertThat(form.getCriteria(), is(notNullValue()));
-        assertThat(form.getCriteria().size(), is(2));
+        assertThat(form.getCriteria(), hasSize(2));
         assertThat(form.getCriteria().get(0).getName(), is("yamada"));
         assertThat(form.getCriteria().get(0).getAge(), is(20));
         assertThat(form.getCriteria().get(1).getName(), is("tanaka"));
@@ -113,7 +115,7 @@ public class ObjectToMapConverterTest {
                 new SearchAndBatchUpdateUserForm3(new SearchUserCriteriaForm3("suzuki", 30), Arrays
                         .asList(new User3("yamada", 20),
                                 new User3("tanaka", 50))));
-        assertThat(map.size(), is(6));
+        assertThat(map, aMapWithSize(6));
         assertThat(map, hasEntry("criteria.name", "suzuki"));
         assertThat(map, hasEntry("criteria.age", "30"));
         assertThat(map, hasEntry("users[0].name", "yamada"));
@@ -129,7 +131,7 @@ public class ObjectToMapConverterTest {
         assertThat(form.getCriteria().getName(), is("suzuki"));
         assertThat(form.getCriteria().getAge(), is(30));
         assertThat(form.getUsers(), is(notNullValue()));
-        assertThat(form.getUsers().size(), is(2));
+        assertThat(form.getUsers(), hasSize(2));
         assertThat(form.getUsers().get(0).getName(), is("yamada"));
         assertThat(form.getUsers().get(0).getAge(), is(20));
         assertThat(form.getUsers().get(1).getName(), is("tanaka"));
@@ -144,7 +146,7 @@ public class ObjectToMapConverterTest {
         source.put("ccc", "333");
         Map<String, String> map = converter.convert(new SearchForm4(source));
 
-        assertThat(map.size(), is(3));
+        assertThat(map, aMapWithSize(3));
         assertThat(map, hasEntry("etc[aaa]", "111"));
         assertThat(map, hasEntry("etc[bbb]", "222"));
         assertThat(map, hasEntry("etc[ccc]", "333"));
@@ -154,7 +156,7 @@ public class ObjectToMapConverterTest {
         WebDataBinder binder = new WebDataBinder(form);
         binder.bind(new MutablePropertyValues(map));
         assertThat(form.getEtc(), is(notNullValue()));
-        assertThat(form.getEtc().size(), is(3));
+        assertThat(form.getEtc(), aMapWithSize(3));
         assertThat(form.getEtc(), hasEntry("aaa", "111"));
         assertThat(form.getEtc(), hasEntry("bbb", "222"));
         assertThat(form.getEtc(), hasEntry("ccc", "333"));
@@ -170,7 +172,7 @@ public class ObjectToMapConverterTest {
         Map<String, String> map = converter.convert(new DateForm5(date1
                 .toDate(), localDate1, new DateFormItem5(date2
                         .toDate(), localDate2)));
-        assertThat(map.size(), is(4));
+        assertThat(map, aMapWithSize(4));
         assertThat(map, hasEntry("date", "2015-04-01"));
         assertThat(map, hasEntry("localDate", "2015-06-10"));
         assertThat(map, hasEntry("item.date", "2015-05-01"));
@@ -197,7 +199,7 @@ public class ObjectToMapConverterTest {
                                                         16 }, new String[] {
                                                                 "d", "e",
                                                                 "f" })));
-        assertThat(map.size(), is(22));
+        assertThat(map, aMapWithSize(22));
         assertThat(map, hasEntry("array1[0]", "1"));
         assertThat(map, hasEntry("array1[1]", "2"));
         assertThat(map, hasEntry("array1[2]", "3"));
@@ -278,7 +280,7 @@ public class ObjectToMapConverterTest {
         form.setNestedForm2(nestedForm);
         Map<String, String> map = converter.convert(form);
 
-        assertThat(map.size(), is(20));
+        assertThat(map, aMapWithSize(20));
         assertThat(map, hasEntry("_string", ""));
         assertThat(map, hasEntry("_integer", ""));
         assertThat(map, hasEntry("_date", ""));
@@ -306,7 +308,7 @@ public class ObjectToMapConverterTest {
         EmptyElementForm10 form = new EmptyElementForm10();
         Map<String, String> map = converter.convert(form);
 
-        assertThat(map.size(), is(4));
+        assertThat(map, aMapWithSize(4));
         assertThat(map, hasEntry("list", ""));
         assertThat(map, hasEntry("array", ""));
         assertThat(map, hasEntry("nestedForm.list", ""));
@@ -318,7 +320,7 @@ public class ObjectToMapConverterTest {
         BooleanForm11 form = new BooleanForm11(true, false, null);
         Map<String, String> map = converter.convert(form);
 
-        assertThat(map.size(), is(3));
+        assertThat(map, aMapWithSize(3));
         assertThat(map, hasEntry("bool1", "true"));
         assertThat(map, hasEntry("bool2", "false"));
         assertThat(map, hasEntry("bool3", ""));

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilterTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilterTest.java
@@ -15,7 +15,9 @@
  */
 package org.terasoluna.gfw.web.exception;
 
-import static org.junit.Assert.assertSame;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -92,18 +94,16 @@ public class ExceptionLoggingFilterTest {
     }
 
     @Test
-    public void testDoFilter_occur_ioexception() throws IOException, ServletException {
+    public void testDoFilter_occur_ioexception() {
 
         IOException occurException = new IOException("io exception.");
 
-        doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
-                mockResponse);
-
-        try {
+        IOException e = assertThrows(IOException.class, () -> {
+            doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
+                    mockResponse);
             testTarget.doFilter(mockRequest, mockResponse, mockFilterChain);
-        } catch (IOException e) {
-            assertSame(occurException, e);
-        }
+        });
+        assertThat(e, is(occurException));
 
         verify(mockExceptionLogger, times(1)).error(occurException);
 
@@ -114,14 +114,12 @@ public class ExceptionLoggingFilterTest {
 
         ServletException occurException = new ServletException("servlet exception.");
 
-        doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
-                mockResponse);
-
-        try {
+        ServletException e = assertThrows(ServletException.class, () -> {
+            doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
+                    mockResponse);
             testTarget.doFilter(mockRequest, mockResponse, mockFilterChain);
-        } catch (ServletException e) {
-            assertSame(occurException, e);
-        }
+        });
+        assertThat(e, is(occurException));
 
         verify(mockExceptionLogger, times(1)).error(occurException);
 
@@ -132,14 +130,14 @@ public class ExceptionLoggingFilterTest {
 
         NullPointerException occurException = new NullPointerException("null pointer exception.");
 
-        doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
-                mockResponse);
-
-        try {
-            testTarget.doFilter(mockRequest, mockResponse, mockFilterChain);
-        } catch (NullPointerException e) {
-            assertSame(occurException, e);
-        }
+        NullPointerException e = assertThrows(NullPointerException.class,
+                () -> {
+                    doThrow(occurException).when(mockFilterChain).doFilter(
+                            mockRequest, mockResponse);
+                    testTarget.doFilter(mockRequest, mockResponse,
+                            mockFilterChain);
+                });
+        assertThat(e, is(occurException));
 
         verify(mockExceptionLogger, times(1)).error(occurException);
 
@@ -153,11 +151,12 @@ public class ExceptionLoggingFilterTest {
         doThrow(occurError).when(mockFilterChain).doFilter(mockRequest,
                 mockResponse);
 
-        try {
+        OutOfMemoryError e = assertThrows(OutOfMemoryError.class, () -> {
+            doThrow(occurError).when(mockFilterChain).doFilter(mockRequest,
+                    mockResponse);
             testTarget.doFilter(mockRequest, mockResponse, mockFilterChain);
-        } catch (OutOfMemoryError e) {
-            assertSame(occurError, e);
-        }
+        });
+        assertThat(e, is(occurError));
 
         verify(mockExceptionLogger, times(0)).error((Exception) any());
 
@@ -173,14 +172,12 @@ public class ExceptionLoggingFilterTest {
 
         IOException occurException = new IOException("io exception.");
 
-        doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
-                mockResponse);
-
-        try {
+        IOException e = assertThrows(IOException.class, () -> {
+            doThrow(occurException).when(mockFilterChain).doFilter(mockRequest,
+                    mockResponse);
             testTarget.doFilter(mockRequest, mockResponse, mockFilterChain);
-        } catch (IOException e) {
-            assertSame(occurException, e);
-        }
+        });
+        assertThat(e, is(occurException));
 
         verify(mockExceptionLogger, times(1)).error(occurException);
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/HandlerExceptionResolverLoggingInterceptorTest.java
@@ -33,7 +33,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DuplicateKeyException;
@@ -47,7 +46,6 @@ import org.terasoluna.gfw.common.exception.ResourceNotFoundException;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 
 public class HandlerExceptionResolverLoggingInterceptorTest {
@@ -539,21 +537,10 @@ public class HandlerExceptionResolverLoggingInterceptorTest {
      */
     private void verifyLogging(final String expectedLogMessage,
             final Level expectedLogLevel) {
-        verify(mockAppender).doAppend(argThat(
-                new ArgumentMatcher<LoggingEvent>() {
-                    @Override
-                    public boolean matches(LoggingEvent argument) {
-                        return argument.getFormattedMessage().equals(
-                                expectedLogMessage);
-                    }
-                }));
-        verify(mockAppender).doAppend(argThat(
-                new ArgumentMatcher<LoggingEvent>() {
-                    @Override
-                    public boolean matches(LoggingEvent argument) {
-                        return expectedLogLevel.equals(argument.getLevel());
-                    }
-                }));
+        verify(mockAppender).doAppend(argThat(argument -> argument
+                .getFormattedMessage().equals(expectedLogMessage)));
+        verify(mockAppender).doAppend(argThat(argument -> expectedLogLevel
+                .equals(argument.getLevel())));
 
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/SystemExceptionResolverTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/exception/SystemExceptionResolverTest.java
@@ -18,6 +18,10 @@ package org.terasoluna.gfw.web.exception;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasToString;
 
 import java.util.Enumeration;
 import java.util.Locale;
@@ -74,7 +78,7 @@ public class SystemExceptionResolverTest {
 
         assertThat(mockRequest.getAttributeNames().hasMoreElements(), is(
                 false));
-        assertThat(mockResponse.getHeaderNames().isEmpty(), is(true));
+        assertThat(mockResponse.getHeaderNames(), is(empty()));
 
     }
 
@@ -90,11 +94,11 @@ public class SystemExceptionResolverTest {
         testTarget.setExceptionCode(occurException, mockRequest, mockResponse);
 
         Enumeration<String> attributeNames = mockRequest.getAttributeNames();
-        assertThat(attributeNames.nextElement().equals(
-                DispatcherServlet.OUTPUT_FLASH_MAP_ATTRIBUTE), is(true));
+        assertThat(attributeNames.nextElement(), is(
+                DispatcherServlet.OUTPUT_FLASH_MAP_ATTRIBUTE));
         assertThat(attributeNames.hasMoreElements(), is(false));
-        assertThat(mockResponse.getHeaderNames().isEmpty(), is(true));
-        assertThat(flashMap.isEmpty(), is(true));
+        assertThat(mockResponse.getHeaderNames(), is(empty()));
+        assertThat(flashMap, is(anEmptyMap()));
 
     }
 
@@ -109,11 +113,11 @@ public class SystemExceptionResolverTest {
 
         testTarget.setExceptionCode(occurException, mockRequest, mockResponse);
 
-        assertThat(mockRequest.getAttribute("exceptionCode").toString(), is(
+        assertThat(mockRequest.getAttribute("exceptionCode"), hasToString(
                 "code001"));
         assertThat(mockResponse.getHeader("X-Exception-Code"), is("code001"));
 
-        assertThat((String) flashMap.get("exceptionCode"), is("code001"));
+        assertThat(flashMap, hasEntry("exceptionCode", "code001"));
 
     }
 
@@ -129,7 +133,7 @@ public class SystemExceptionResolverTest {
 
         assertThat(mockRequest.getAttributeNames().hasMoreElements(), is(
                 false));
-        assertThat(mockResponse.getHeaderNames().isEmpty(), is(true));
+        assertThat(mockResponse.getHeaderNames(), is(empty()));
 
     }
 
@@ -145,7 +149,7 @@ public class SystemExceptionResolverTest {
 
         assertThat(mockRequest.getAttributeNames().hasMoreElements(), is(
                 false));
-        assertThat(mockResponse.getHeaderNames().isEmpty(), is(true));
+        assertThat(mockResponse.getHeaderNames(), is(empty()));
 
     }
 
@@ -188,9 +192,9 @@ public class SystemExceptionResolverTest {
 
         testTarget.setExceptionCode(occurException, mockRequest, mockResponse);
 
-        assertThat(mockRequest.getAttribute("exceptionCode").toString(), is(
+        assertThat(mockRequest.getAttribute("exceptionCode"), hasToString(
                 "code001"));
-        assertThat(mockResponse.getHeaderNames().isEmpty(), is(true));
+        assertThat(mockResponse.getHeaderNames(), is(empty()));
 
     }
 
@@ -203,9 +207,9 @@ public class SystemExceptionResolverTest {
 
         testTarget.setExceptionCode(occurException, mockRequest, mockResponse);
 
-        assertThat(mockRequest.getAttribute("exceptionCode").toString(), is(
+        assertThat(mockRequest.getAttribute("exceptionCode"), hasToString(
                 "code001"));
-        assertThat(mockResponse.getHeaderNames().isEmpty(), is(true));
+        assertThat(mockResponse.getHeaderNames(), is(empty()));
 
     }
 
@@ -251,7 +255,7 @@ public class SystemExceptionResolverTest {
 
         testTarget.setResultMessages(occurException, mockRequest);
 
-        assertThat(flashMap.isEmpty(), is(true));
+        assertThat(flashMap, is(anEmptyMap()));
 
     }
 
@@ -269,7 +273,7 @@ public class SystemExceptionResolverTest {
 
         testTarget.setResultMessages(occurException, mockRequest);
 
-        assertThat(flashMap.isEmpty(), is(true));
+        assertThat(flashMap, is(anEmptyMap()));
 
     }
 
@@ -287,7 +291,7 @@ public class SystemExceptionResolverTest {
 
         testTarget.setResultMessages(occurException, mockRequest);
 
-        assertThat(flashMap.isEmpty(), is(true));
+        assertThat(flashMap, is(anEmptyMap()));
 
     }
 
@@ -310,7 +314,7 @@ public class SystemExceptionResolverTest {
         testTarget.setExceptionInfo(occurException, mockRequest, mockResponse);
 
         // do assert.
-        assertThat(mockRequest.getAttribute("exceptionCode").toString(), is(
+        assertThat(mockRequest.getAttribute("exceptionCode"), hasToString(
                 "defaultCode"));
         assertThat(mockResponse.getHeader("X-Exception-Code"), is(
                 "defaultCode"));
@@ -370,7 +374,7 @@ public class SystemExceptionResolverTest {
         assertThat(occurException, is(actualModleAndView.getModel().get(
                 SimpleMappingExceptionResolver.DEFAULT_EXCEPTION_ATTRIBUTE)));
 
-        assertThat(mockRequest.getAttribute("exceptionCode").toString(), is(
+        assertThat(mockRequest.getAttribute("exceptionCode"), hasToString(
                 "defaultExceptionCode"));
         assertThat(mockResponse.getHeader("X-Exception-Code"), is(
                 "defaultExceptionCode"));

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/HttpSessionEventLoggingListenerTest.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpSessionEvent;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockHttpSession;
 import org.terasoluna.gfw.web.logback.LogLevelChangeUtil;
@@ -35,7 +34,6 @@ import org.terasoluna.gfw.web.logback.LogLevelChangeUtil;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 
 public class HttpSessionEventLoggingListenerTest {
@@ -276,21 +274,10 @@ public class HttpSessionEventLoggingListenerTest {
      */
     private void verifyLogging(final String expectedLogMessage,
             final Level expectedLogLevel) {
-        verify(mockAppender).doAppend(argThat(
-                new ArgumentMatcher<LoggingEvent>() {
-                    @Override
-                    public boolean matches(LoggingEvent argument) {
-                        return argument.getFormattedMessage().equals(
-                                expectedLogMessage);
-                    }
-                }));
-        verify(mockAppender).doAppend(argThat(
-                new ArgumentMatcher<LoggingEvent>() {
-                    @Override
-                    public boolean matches(LoggingEvent argument) {
-                        return expectedLogLevel.equals(argument.getLevel());
-                    }
-                }));
+        verify(mockAppender).doAppend(argThat(argument -> argument
+                .getFormattedMessage().equals(expectedLogMessage)));
+        verify(mockAppender).doAppend(argThat(argument -> expectedLogLevel
+                .equals(argument.getLevel())));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/TraceLoggingInterceptorTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -39,7 +38,6 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
@@ -57,7 +55,6 @@ import com.google.common.collect.ImmutableList;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 
 @ContextConfiguration(locations = "classpath:/test-context.xml")
@@ -129,12 +126,8 @@ public class TraceLoggingInterceptorTest {
         HandlerMethod paramHandler = new HandlerMethod(controller, TraceLoggingInterceptorController.class
                 .getMethod("createForm"));
 
-        try {
-            // run
-            interceptor.preHandle(request, response, paramHandler);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.preHandle(request, response, paramHandler);
 
         String logMessage = jdbcTemplate.queryForObject(
                 "SELECT FORMATTED_MESSAGE FROM LOGGING_EVENT WHERE EVENT_ID=:id",
@@ -157,12 +150,8 @@ public class TraceLoggingInterceptorTest {
         // parameter create
         Object paramHandler = new Object();
 
-        try {
-            // run
-            interceptor.preHandle(request, response, paramHandler);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.preHandle(request, response, paramHandler);
 
         // expected
         Long startTime = (Long) request.getAttribute(
@@ -184,12 +173,8 @@ public class TraceLoggingInterceptorTest {
         // parameter create
         Object paramHandler = new Object();
 
-        try {
-            // run
-            interceptor.preHandle(request, response, paramHandler);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.preHandle(request, response, paramHandler);
 
         // expected
         Long startTime = (Long) request.getAttribute(
@@ -220,12 +205,8 @@ public class TraceLoggingInterceptorTest {
         request.setAttribute(TraceLoggingInterceptor.class.getName()
                 + ".startTime", startTime);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         String logMessage1 = jdbcTemplate.queryForObject(
@@ -258,12 +239,8 @@ public class TraceLoggingInterceptorTest {
         View view = mock(View.class);
         when(model.getView()).thenReturn(view);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         String expectedLogStr = "TraceLoggingInterceptorController.second(SampleForm,Model)->";
@@ -285,12 +262,8 @@ public class TraceLoggingInterceptorTest {
                 + ".startTime", startTime);
         HandlerMethod paramHandler = new HandlerMethod(controller, method[0]);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, null);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, null);
 
         // expected
         String expectedLogStr = "TraceLoggingInterceptorController.createForm()->";
@@ -312,13 +285,9 @@ public class TraceLoggingInterceptorTest {
                 + ".startTime", startTime);
         HandlerMethod paramHandler = new HandlerMethod(controller, method[0]);
 
-        try {
-            // run
-            interceptor.setWarnHandlingNanos(1L);
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.setWarnHandlingNanos(1L);
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         String expectedLogStr = "TraceLoggingInterceptorController.createForm()->";
@@ -338,12 +307,8 @@ public class TraceLoggingInterceptorTest {
         // parameter create
         HandlerMethod paramHandler = new HandlerMethod(controller, method[0]);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         String expectedLogStr = "TraceLoggingInterceptorController.createForm()->";
@@ -360,12 +325,8 @@ public class TraceLoggingInterceptorTest {
         // parameter create
         Object paramHandler = new Object();
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         final String expectedLogStr = "TraceLoggingInterceptorController.createForm()->";
@@ -386,12 +347,8 @@ public class TraceLoggingInterceptorTest {
                 + ".startTime", startTime);
         Object paramHandler = new Object();
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         String expectedLogStr = "[HANDLING TIME   ]->";
@@ -412,13 +369,9 @@ public class TraceLoggingInterceptorTest {
                 + ".startTime", startTime);
         Object paramHandler = new Object();
 
-        try {
-            // run
-            interceptor.setWarnHandlingNanos(1L);
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.setWarnHandlingNanos(1L);
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // expected
         String expectedLogStr = "[HANDLING TIME   ]->";
@@ -435,12 +388,8 @@ public class TraceLoggingInterceptorTest {
         request.setAttribute(TraceLoggingInterceptor.class.getName()
                 + ".startTime", null);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, null);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, null);
 
         // expected
         String expectedLogStr = "[HANDLING TIME   ] TraceLoggingInterceptorController.createForm()->";
@@ -461,12 +410,8 @@ public class TraceLoggingInterceptorTest {
         request.setAttribute(TraceLoggingInterceptor.class.getName()
                 + ".startTime", startTime);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // assert
         assertThat(logger.isDebugEnabled(), is(false));
@@ -487,12 +432,8 @@ public class TraceLoggingInterceptorTest {
         request.setAttribute(TraceLoggingInterceptor.class.getName()
                 + ".startTime", startTime);
 
-        try {
-            // run
-            interceptor.postHandle(request, response, paramHandler, model);
-        } catch (Exception e) {
-            fail("illegal case");
-        }
+        // run
+        interceptor.postHandle(request, response, paramHandler, model);
 
         // assert
         assertThat(logger.isDebugEnabled(), is(false));
@@ -510,13 +451,8 @@ public class TraceLoggingInterceptorTest {
     private void verifyLogging(final String expectedLogMessage,
             final List<Level> expectedLogLevel, final int expectedCallCount) {
         verify(mockAppender, times(expectedCallCount)).doAppend(argThat(
-                new ArgumentMatcher<LoggingEvent>() {
-                    @Override
-                    public boolean matches(LoggingEvent argument) {
-                        return expectedLogLevel.contains(argument.getLevel())
-                                && argument.getFormattedMessage().contains(
-                                        expectedLogMessage);
-                    }
-                }));
+                argument -> expectedLogLevel.contains(argument.getLevel())
+                        && argument.getFormattedMessage().contains(
+                                expectedLogMessage)));
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/AbstractMDCPutFilterTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/AbstractMDCPutFilterTest.java
@@ -18,7 +18,8 @@ package org.terasoluna.gfw.web.logging.mdc;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -124,7 +125,8 @@ public class AbstractMDCPutFilterTest {
 
         // do assert.
         // put value to MDC.
-        assertThat(mockFilterChain.actualMdcContextMap.size(), is(2));
+        assertThat((Map<?, ?>) mockFilterChain.actualMdcContextMap,
+                aMapWithSize(2));
         assertThat(mockFilterChain.actualMdcPutValue, is("value"));
 
         // call filter chain.
@@ -132,7 +134,7 @@ public class AbstractMDCPutFilterTest {
 
         // remove value in MDC.
         // not remove other value from MDC.
-        assertThat(MDC.getCopyOfContextMap().size(), is(1));
+        assertThat(MDC.getCopyOfContextMap(), aMapWithSize(1));
         assertThat(MDC.get("dummyKey"), is("dummyValue"));
 
     }
@@ -160,20 +162,18 @@ public class AbstractMDCPutFilterTest {
                 mockResponse);
 
         // do test.
-        try {
+        ServletException e = assertThrows(ServletException.class, () -> {
             testTarget.doFilterInternal(mockRequest, mockResponse,
                     mockFilterChain);
-            fail("don't occur ServletException.");
-        } catch (ServletException e) {
-            // do assert.
-            // throws original exception.
-            assertThat(e, is(occurException));
-        }
+        });
+        // do assert.
+        // throws original exception.
+        assertThat(e, is(occurException));
 
         // do assert.
         // remove value in MDC.
         // not remove other value from MDC.
-        assertThat(MDC.getCopyOfContextMap().size(), is(1));
+        assertThat(MDC.getCopyOfContextMap(), aMapWithSize(1));
         assertThat(MDC.get("dummyKey"), is("dummyValue"));
 
     }
@@ -200,7 +200,7 @@ public class AbstractMDCPutFilterTest {
 
         // do assert.
         // not remove other value from MDC.
-        assertThat(MDC.getCopyOfContextMap().size(), is(2));
+        assertThat(MDC.getCopyOfContextMap(), aMapWithSize(2));
         assertThat(MDC.get("dummyKey"), is("dummyValue"));
         assertThat(MDC.get("key"), is("value"));
 
@@ -229,19 +229,17 @@ public class AbstractMDCPutFilterTest {
                 mockResponse);
 
         // do test.
-        try {
+        IOException e = assertThrows(IOException.class, () -> {
             testTarget.doFilterInternal(mockRequest, mockResponse,
                     mockFilterChain);
-            fail("don't occur IOException.");
-        } catch (IOException e) {
-            // do assert.
-            // throws original io exception.
-            assertThat(e, is(occurException));
-        }
+        });
+        // do assert.
+        // throws original io exception.
+        assertThat(e, is(occurException));
 
         // do assert.
         // not remove other value from MDC.
-        assertThat(MDC.getCopyOfContextMap().size(), is(2));
+        assertThat(MDC.getCopyOfContextMap(), aMapWithSize(2));
         assertThat(MDC.get("dummyKey"), is("dummyValue"));
         assertThat(MDC.get("key"), is("value"));
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/MDCClearFilterTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/MDCClearFilterTest.java
@@ -18,7 +18,9 @@ package org.terasoluna.gfw.web.logging.mdc;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
@@ -99,9 +101,9 @@ public class MDCClearFilterTest {
 
         // do assert.
         // not remove existing values from MDC on before chain.
-        assertThat(mockFilterChain.actualMdcContextMap.size(), is(1));
-        assertThat(mockFilterChain.actualMdcContextMap.containsKey("key0"), is(
-                true));
+        Map<?, ?> actualMdcContextMap = mockFilterChain.actualMdcContextMap;
+        assertThat(actualMdcContextMap, aMapWithSize(1));
+        assertThat(actualMdcContextMap, hasKey("key0"));
         // remove all values from MDC on after chain.
         assertThat(MDC.getCopyOfContextMap(), is(nullValue()));
     }
@@ -126,15 +128,13 @@ public class MDCClearFilterTest {
         MDC.put("key0", "value0");
 
         // do test.
-        try {
+        ServletException e = assertThrows(ServletException.class, () -> {
             testTarget.doFilterInternal(mockRequest, mockResponse,
                     mockFilterChain);
-            fail("don't occur ServletException.");
-        } catch (ServletException e) {
-            // do assert.
-            // throws original exception.
-            assertThat(e, is(occurException));
-        }
+        });
+        // do assert.
+        // throws original exception.
+        assertThat(e, is(occurException));
 
         // do assert.
         // remove all values from MDC on after chain.

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/XTrackMDCPutFilterTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/logging/mdc/XTrackMDCPutFilterTest.java
@@ -16,8 +16,8 @@
 package org.terasoluna.gfw.web.logging.mdc;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 
 import javax.servlet.ServletException;
 
@@ -57,10 +57,9 @@ public class XTrackMDCPutFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         String xTrack = xTrackMDCPutFilter.getMDCValue(request, response);
-        assertThat(xTrack, is(notNullValue()));
-        assertThat(xTrack.matches("^[a-f0-9]{32}$"), is(true));
+        assertThat(xTrack, matchesPattern("^[a-f0-9]{32}$"));
         assertThat(response.getHeader("X-Track"), is(xTrack));
-        assertThat((String) request.getAttribute("X-Track"), is(xTrack));
+        assertThat(request.getAttribute("X-Track"), is(xTrack));
     }
 
     @Test
@@ -70,10 +69,9 @@ public class XTrackMDCPutFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         String xTrack = xTrackMDCPutFilter.getMDCValue(request, response);
-        assertThat(xTrack, is(notNullValue()));
-        assertThat(xTrack.matches("^[a-f0-9]{32}$"), is(true));
+        assertThat(xTrack, matchesPattern("^[a-f0-9]{32}$"));
         assertThat(response.getHeader("X-Hoge"), is(xTrack));
-        assertThat((String) request.getAttribute("X-Hoge"), is(xTrack));
+        assertThat(request.getAttribute("X-Hoge"), is(xTrack));
     }
 
     @Test
@@ -84,10 +82,9 @@ public class XTrackMDCPutFilterTest {
 
         request.addHeader("X-Track", "hoge");
         String xTrack = xTrackMDCPutFilter.getMDCValue(request, response);
-        assertThat(xTrack, is(notNullValue()));
         assertThat(xTrack, is("hoge"));
         assertThat(response.getHeader("X-Track"), is("hoge"));
-        assertThat((String) request.getAttribute("X-Track"), is("hoge"));
+        assertThat(request.getAttribute("X-Track"), is("hoge"));
     }
 
     @Test
@@ -99,11 +96,10 @@ public class XTrackMDCPutFilterTest {
 
         request.addHeader("X-Hoge", "12345678901234567890123456789012");
         String xTrack = xTrackMDCPutFilter.getMDCValue(request, response);
-        assertThat(xTrack, is(notNullValue()));
         assertThat(xTrack, is("12345678901234567890123456789012"));
         assertThat(response.getHeader("X-Hoge"), is(
                 "12345678901234567890123456789012"));
-        assertThat((String) request.getAttribute("X-Hoge"), is(
+        assertThat(request.getAttribute("X-Hoge"), is(
                 "12345678901234567890123456789012"));
     }
 
@@ -116,11 +112,10 @@ public class XTrackMDCPutFilterTest {
         request.addHeader("X-Track",
                 "12345678901234567890123456789012345678901234567890");
         String xTrack = xTrackMDCPutFilter.getMDCValue(request, response);
-        assertThat(xTrack, is(notNullValue()));
         assertThat(xTrack, is("12345678901234567890123456789012"));
         assertThat(response.getHeader("X-Track"), is(
                 "12345678901234567890123456789012"));
-        assertThat((String) request.getAttribute("X-Track"), is(
+        assertThat(request.getAttribute("X-Track"), is(
                 "12345678901234567890123456789012"));
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationInfoTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/pagination/PaginationInfoTest.java
@@ -16,8 +16,10 @@
 package org.terasoluna.gfw.web.pagination;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -92,12 +94,10 @@ public class PaginationInfoTest {
                 page, size, null);
 
         // assert
-        assertThat(Integer.valueOf(attributesMap.get("page").toString()), is(
-                page));
-        assertThat(Integer.valueOf(attributesMap.get("size").toString()), is(
-                size));
-        assertThat(attributesMap.get("sortOrderProperty"), is(nullValue()));
-        assertThat(attributesMap.get("sortOrderDirection"), is(nullValue()));
+        assertThat(attributesMap, hasEntry("page", page));
+        assertThat(attributesMap, hasEntry("size", size));
+        assertThat(attributesMap, not(hasKey("sortOrderProperty")));
+        assertThat(attributesMap, not(hasKey("sortOrderDirection")));
     }
 
     /**
@@ -115,13 +115,10 @@ public class PaginationInfoTest {
                 page, size, mockedSort);
 
         // assert
-        assertThat(Integer.valueOf(attributesMap.get("page").toString()), is(
-                page));
-        assertThat(Integer.valueOf(attributesMap.get("size").toString()), is(
-                size));
-        assertThat(attributesMap.get("sortOrderProperty").toString(), is("id"));
-        assertThat(attributesMap.get("sortOrderDirection").toString(), is(
-                "DESC"));
+        assertThat(attributesMap, hasEntry("page", page));
+        assertThat(attributesMap, hasEntry("size", size));
+        assertThat(attributesMap, hasEntry("sortOrderProperty", "id"));
+        assertThat(attributesMap, hasEntry("sortOrderDirection", "DESC"));
     }
 
     @Test
@@ -141,12 +138,10 @@ public class PaginationInfoTest {
                 page, size, sort);
 
         // assert
-        assertThat(Integer.valueOf(attributesMap.get("page").toString()), is(
-                page));
-        assertThat(Integer.valueOf(attributesMap.get("size").toString()), is(
-                size));
-        assertThat(attributesMap.get("sortOrderProperty"), is(nullValue()));
-        assertThat(attributesMap.get("sortOrderDirection"), is(nullValue()));
+        assertThat(attributesMap, hasEntry("page", page));
+        assertThat(attributesMap, hasEntry("size", size));
+        assertThat(attributesMap, not(hasKey("sortOrderProperty")));
+        assertThat(attributesMap, not(hasKey("sortOrderDirection")));
     }
 
     @Test

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/TokenStringGeneratorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/TokenStringGeneratorTest.java
@@ -19,7 +19,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.hasLength;
+import static org.junit.Assert.assertThrows;
 
 import java.security.NoSuchAlgorithmException;
 
@@ -27,29 +28,25 @@ import org.junit.Test;
 
 public class TokenStringGeneratorTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidTokenGeneratorAlgorithm() throws Exception {
-        try {
-            new TokenStringGenerator("InvalidAlgorithm");
-        } catch (Exception e) {
-            assertThat(e.getCause(), is(instanceOf(
-                    NoSuchAlgorithmException.class)));
-            assertThat(e.getMessage(), is(
-                    "The given algorithm is invalid. algorithm=InvalidAlgorithm"));
-            throw e;
-        }
-        fail();
+    @Test
+    public void testInvalidTokenGeneratorAlgorithm() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new TokenStringGenerator("InvalidAlgorithm");
+                });
+        assertThat(e.getCause(), is(instanceOf(
+                NoSuchAlgorithmException.class)));
+        assertThat(e.getMessage(), is(
+                "The given algorithm is invalid. algorithm=InvalidAlgorithm"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullTokenGeneratorAlgorithm() throws Exception {
-        try {
-            new TokenStringGenerator(null);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("algorithm must not be null"));
-            throw e;
-        }
-        fail();
+    @Test
+    public void testNullTokenGeneratorAlgorithm() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new TokenStringGenerator(null);
+                });
+        assertThat(e.getMessage(), is("algorithm must not be null"));
     }
 
     @Test
@@ -57,7 +54,7 @@ public class TokenStringGeneratorTest {
         TokenStringGenerator generator = new TokenStringGenerator();
         String value = generator.generate("hoge");
         assertThat(value, is(notNullValue()));
-        assertThat(value.length(), is(32));
+        assertThat(value, hasLength(32));
     }
 
     @Test
@@ -65,7 +62,7 @@ public class TokenStringGeneratorTest {
         TokenStringGenerator generator = new TokenStringGenerator();
         String value = generator.generate("");
         assertThat(value, is(notNullValue()));
-        assertThat(value.length(), is(32));
+        assertThat(value, hasLength(32));
     }
 
     @Test
@@ -73,18 +70,18 @@ public class TokenStringGeneratorTest {
         TokenStringGenerator generator = new TokenStringGenerator("SHA-256");
         String value = generator.generate("hoge");
         assertThat(value, is(notNullValue()));
-        assertThat(value.length(), is(64));
+        assertThat(value, hasLength(64));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGenerate_nullValue() throws Exception {
         TokenStringGenerator generator = new TokenStringGenerator();
-        try {
-            generator.generate(null);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("seed must not be null"));
-            throw e;
-        }
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    generator.generate(null);
+                });
+        assertThat(e.getMessage(), is("seed must not be null"));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStoreTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStoreTest.java
@@ -19,8 +19,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
-import java.util.Enumeration;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpSession;
@@ -120,15 +120,15 @@ public class HttpSessionTransactionTokenStoreTest {
                                 notNullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testGetAndClear_tokenIsNull() throws Exception {
-        try {
-            store = new HttpSessionTransactionTokenStore();
-            store.getAndClear(null);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("token must not be null"));
-            throw e;
-        }
+    @Test
+    public void testGetAndClear_tokenIsNull() {
+        store = new HttpSessionTransactionTokenStore();
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    store.getAndClear(null);
+                });
+        assertThat(e.getMessage(), is("token must not be null"));
     }
 
     @Test
@@ -152,15 +152,15 @@ public class HttpSessionTransactionTokenStoreTest {
                                 nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRemove_tokenIsNull() throws Exception {
-        try {
-            store = new HttpSessionTransactionTokenStore();
-            store.remove(null);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("token must not be null"));
-            throw e;
-        }
+        store = new HttpSessionTransactionTokenStore();
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    store.remove(null);
+                });
+        assertThat(e.getMessage(), is("token must not be null"));
     }
 
     /**
@@ -198,12 +198,6 @@ public class HttpSessionTransactionTokenStoreTest {
 
         // run
         String actual = store.createAndReserveTokenKey(tokenA.getTokenName());
-        Enumeration<String> enumeration = session.getAttributeNames();
-        while (enumeration.hasMoreElements()) {
-            System.out.println(enumeration.nextElement());
-        }
-
-        // String expected = "";
 
         // assert
         assertThat(actual, is(notNullValue()));
@@ -261,12 +255,6 @@ public class HttpSessionTransactionTokenStoreTest {
 
         // run
         String actual = store.createAndReserveTokenKey(tokenA.getTokenName());
-        Enumeration<String> enumeration = session.getAttributeNames();
-        while (enumeration.hasMoreElements()) {
-            System.out.println(enumeration.nextElement());
-        }
-
-        // String expected = "";
 
         // assert
         assertThat(actual, is(notNullValue()));
@@ -329,12 +317,6 @@ public class HttpSessionTransactionTokenStoreTest {
 
         // run
         String actual = store.createAndReserveTokenKey(tokenA.getTokenName());
-        Enumeration<String> enumeration = session.getAttributeNames();
-        while (enumeration.hasMoreElements()) {
-            System.out.println(enumeration.nextElement());
-        }
-
-        // String expected = "";
 
         // assert
         assertThat(actual, is(notNullValue()));
@@ -386,8 +368,6 @@ public class HttpSessionTransactionTokenStoreTest {
         // run
         String actual = store.createAndReserveTokenKey(tokenA.getTokenName());
 
-        // String expected = "";
-
         // assert
         assertThat(actual, is(notNullValue()));
         assertThat(session.getAttribute(store.createSessionAttributeName(
@@ -404,8 +384,8 @@ public class HttpSessionTransactionTokenStoreTest {
                 token3)), is(notNullValue()));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testCreateAndReserveTokenKey_generate_failed() throws Exception {
+    @Test
+    public void testCreateAndReserveTokenKey_generate_failed() {
         // prepare store instance
         store = new HttpSessionTransactionTokenStore(new TokenStringGenerator() {
             @Override
@@ -423,81 +403,72 @@ public class HttpSessionTransactionTokenStoreTest {
                 HttpSessionTransactionTokenStore.TOKEN_HOLDER_SESSION_ATTRIBUTE_PREFIX
                         + "foo" + TransactionToken.TOKEN_STRING_SEPARATOR
                         + "xxxxx", "already in!");
-        try {
-            store.createAndReserveTokenKey("foo");
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is(
-                    "token key generation failed within retry count 5"));
-            throw e;
-        }
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> {
+                    store.createAndReserveTokenKey("foo");
+                });
+        assertThat(e.getMessage(), is(
+                "token key generation failed within retry count 5"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testStore_token_isNull() throws Exception {
-        try {
-            store = new HttpSessionTransactionTokenStore(5);
-            store.store(null);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("token must not be null"));
-            throw e;
-        }
+    @Test
+    public void testStore_token_isNull() {
+        store = new HttpSessionTransactionTokenStore(5);
+
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    store.store(null);
+                });
+        assertThat(e.getMessage(), is("token must not be null"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_generator_isNull() throws Exception {
-        try {
-            new HttpSessionTransactionTokenStore(null, 10, 10);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("generator must not be null"));
-            throw e;
-        }
+    @Test
+    public void testConstructor_generator_isNull() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new HttpSessionTransactionTokenStore(null, 10, 10);
+                });
+        assertThat(e.getMessage(), is("generator must not be null"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_transactionTokensPerTokenName_isZero() throws Exception {
-        try {
-            new HttpSessionTransactionTokenStore(new TokenStringGenerator(), 0, 1);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is(
-                    "transactionTokenSizePerTokenName must be greater than 0"));
-            throw e;
-        }
-
+    @Test
+    public void testConstructor_transactionTokensPerTokenName_isZero() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new HttpSessionTransactionTokenStore(new TokenStringGenerator(), 0, 1);
+                });
+        assertThat(e.getMessage(), is(
+                "transactionTokenSizePerTokenName must be greater than 0"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_transactionTokensPerTokenName_isNegative() throws Exception {
-        try {
-            new HttpSessionTransactionTokenStore(new TokenStringGenerator(), -1, 0);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is(
-                    "transactionTokenSizePerTokenName must be greater than 0"));
-            throw e;
-        }
-
+    @Test
+    public void testConstructor_transactionTokensPerTokenName_isNegative() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new HttpSessionTransactionTokenStore(new TokenStringGenerator(), -1, 0);
+                });
+        assertThat(e.getMessage(), is(
+                "transactionTokenSizePerTokenName must be greater than 0"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_retryCreateTokenName_isZero() throws Exception {
-        try {
-            new HttpSessionTransactionTokenStore(new TokenStringGenerator(), 1, 0);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is(
-                    "retryCreateTokenName must be greater than 0"));
-            throw e;
-        }
-
+    @Test
+    public void testConstructor_retryCreateTokenName_isZero() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new HttpSessionTransactionTokenStore(new TokenStringGenerator(), 1, 0);
+                });
+        assertThat(e.getMessage(), is(
+                "retryCreateTokenName must be greater than 0"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructor_retryCreateTokenName_isNegative() throws Exception {
-        try {
-            new HttpSessionTransactionTokenStore(new TokenStringGenerator(), 1, -1);
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is(
-                    "retryCreateTokenName must be greater than 0"));
-            throw e;
-        }
-
+    @Test
+    public void testConstructor_retryCreateTokenName_isNegative() {
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class, () -> {
+                    new HttpSessionTransactionTokenStore(new TokenStringGenerator(), 1, -1);
+                });
+        assertThat(e.getMessage(), is(
+                "retryCreateTokenName must be greater than 0"));
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/InvalidTransactionTokenExceptionTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/InvalidTransactionTokenExceptionTest.java
@@ -17,6 +17,7 @@ package org.terasoluna.gfw.web.token.transaction;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import org.junit.Test;
 
@@ -25,30 +26,22 @@ public class InvalidTransactionTokenExceptionTest {
     @Test
     public void testExceptionConstructor() {
 
-        try {
-            process();
-        } catch (InvalidTransactionTokenException e) {
-            assertThat(e.getMessage(), is(
-                    "Invalid Transaction Token Exception !!!"));
-        }
+        InvalidTransactionTokenException e = assertThrows(
+                InvalidTransactionTokenException.class, () -> {
+                    throw new InvalidTransactionTokenException();
+                });
+        assertThat(e.getMessage(), is(
+                "Invalid Transaction Token Exception !!!"));
     }
 
     @Test
     public void testExceptionConstructorWithCustomMessage() {
 
-        try {
-            processOther();
-        } catch (InvalidTransactionTokenException e) {
-            assertThat(e.getMessage(), is("Custom Message"));
-        }
-    }
-
-    private void processOther() {
-        throw new InvalidTransactionTokenException("Custom Message");
-    }
-
-    private void process() {
-        throw new InvalidTransactionTokenException();
+        InvalidTransactionTokenException e = assertThrows(
+                InvalidTransactionTokenException.class, () -> {
+                    throw new InvalidTransactionTokenException("Custom Message");
+                });
+        assertThat(e.getMessage(), is("Custom Message"));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextHandlerMethodArgumentResolverTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenContextHandlerMethodArgumentResolverTest.java
@@ -93,12 +93,8 @@ public class TransactionTokenContextHandlerMethodArgumentResolverTest {
                 RequestAttributes.SCOPE_REQUEST)).thenReturn(str);
 
         Object result = null;
-        try {
-            result = resolver.resolveArgument(parameter, mavContainer,
-                    webRequest, binderFactory);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        result = resolver.resolveArgument(parameter, mavContainer, webRequest,
+                binderFactory);
 
         assertThat(result, is(instanceOf(String.class)));
     }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenInterceptorTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,6 +26,7 @@ import static org.mockito.Mockito.when;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -254,28 +254,18 @@ public class TransactionTokenInterceptorTest {
         assertThat(token.getTokenName(), is("a"));
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testRemoveEmptyToken() {
         // This test case should always pass
-        // This will ensure that neither valid/invalid token removal generates
-        // exception
-        try {
-            interceptor.removeToken(new TransactionToken(""));
-            interceptor.removeToken(new TransactionToken("a~b~c"));
-        } catch (Exception ex) {
-            fail();
-        }
-
+        // This will ensure that neither valid/invalid token removal generates exception
+        interceptor.removeToken(new TransactionToken(""));
+        interceptor.removeToken(new TransactionToken("a~b~c"));
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testPostHandleIncorrectHandler() throws Exception {
 
-        try {
-            interceptor.postHandle(request, response, null, null);
-        } catch (Exception ex) {
-            fail();
-        }
+        interceptor.postHandle(request, response, null, null);
     }
 
     @Test
@@ -412,7 +402,7 @@ public class TransactionTokenInterceptorTest {
         assertThat(tokenStore.getAndClear(nextToken), is("222"));
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testPostHandleWithNoneOperation() throws Exception {
 
         TransactionTokenContextImpl context = mock(
@@ -425,84 +415,60 @@ public class TransactionTokenInterceptorTest {
         when(context.getReserveCommand()).thenReturn(
                 TransactionTokenContextImpl.ReserveCommand.NONE);
 
-        try {
-            interceptor.postHandle(request, response,
-                    new HandlerMethod(new TransactionTokenSampleController(), TransactionTokenSampleController.class
-                            .getDeclaredMethod("third", SampleForm.class,
-                                    Model.class)), null);
-        } catch (Exception e) {
-            fail();
-        }
+        interceptor.postHandle(request, response,
+                new HandlerMethod(new TransactionTokenSampleController(), TransactionTokenSampleController.class
+                        .getDeclaredMethod("third", SampleForm.class,
+                                Model.class)), null);
 
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testAfterCompletionWithoutException() {
-        try {
-            interceptor.afterCompletion(request, response, null, null);
-        } catch (Exception e) {
-            fail();
-        }
+
+        interceptor.afterCompletion(request, response, null, null);
     }
 
     @Test
-    public void testAfterCompletionWithException() {
-        try {
+    public void testAfterCompletionWithException() throws Exception {
 
-            HttpSessionTransactionTokenStore tokenStore = new HttpSessionTransactionTokenStore();
-            TransactionToken inputToken = new TransactionToken("testTokenAttr", "111", "222");
-            tokenStore.store(inputToken);
+        HttpSessionTransactionTokenStore tokenStore = new HttpSessionTransactionTokenStore();
+        TransactionToken inputToken = new TransactionToken("testTokenAttr", "111", "222");
+        tokenStore.store(inputToken);
 
-            request.setParameter(
-                    TransactionTokenInterceptor.TOKEN_REQUEST_PARAMETER,
-                    "testTokenAttr~111~222");
+        request.setParameter(
+                TransactionTokenInterceptor.TOKEN_REQUEST_PARAMETER,
+                "testTokenAttr~111~222");
 
-            interceptor = new TransactionTokenInterceptor(new TokenStringGenerator(), new TransactionTokenInfoStore(), tokenStore);
+        interceptor = new TransactionTokenInterceptor(new TokenStringGenerator(), new TransactionTokenInfoStore(), tokenStore);
 
-            interceptor.preHandle(request, response,
-                    new HandlerMethod(new TransactionTokenSampleController(), TransactionTokenSampleController.class
-                            .getDeclaredMethod("third", SampleForm.class,
-                                    Model.class)));
+        interceptor.preHandle(request, response,
+                new HandlerMethod(new TransactionTokenSampleController(), TransactionTokenSampleController.class
+                        .getDeclaredMethod("third", SampleForm.class,
+                                Model.class)));
 
-            // Confirm that token is stored in session
-            assertThat(tokenStore.getSession().getAttribute(
-                    HttpSessionTransactionTokenStore.TOKEN_HOLDER_SESSION_ATTRIBUTE_PREFIX
-                            + inputToken.getTokenName() + "~" + inputToken
-                                    .getTokenKey()), is(notNullValue()));
+        // Confirm that token is stored in session
+        assertThat(tokenStore.getSession().getAttribute(
+                HttpSessionTransactionTokenStore.TOKEN_HOLDER_SESSION_ATTRIBUTE_PREFIX
+                        + inputToken.getTokenName() + "~" + inputToken
+                                .getTokenKey()), is(notNullValue()));
 
-            // Consider that exception has occured and call afterCompletion()
-            // method
-            // This call should remove the token from the store
-            Exception ex = new InvalidTransactionTokenException();
-            interceptor.afterCompletion(request, response, null, ex);
+        // Consider that exception has occured and call afterCompletion()
+        // method
+        // This call should remove the token from the store
+        Exception ex = new InvalidTransactionTokenException();
+        interceptor.afterCompletion(request, response, null, ex);
 
-            // Confirm that token is removed from session
-            assertThat(tokenStore.getSession().getAttribute(
-                    HttpSessionTransactionTokenStore.TOKEN_HOLDER_SESSION_ATTRIBUTE_PREFIX
-                            + inputToken.getTokenName() + "~" + inputToken
-                                    .getTokenKey()), is(nullValue()));
+        // Confirm that token is removed from session
+        assertThat(tokenStore.getSession().getAttribute(
+                HttpSessionTransactionTokenStore.TOKEN_HOLDER_SESSION_ATTRIBUTE_PREFIX
+                        + inputToken.getTokenName() + "~" + inputToken
+                                .getTokenKey()), is(nullValue()));
 
-        } catch (Exception e) {
-            fail();
-        }
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testAfterCompletionWithExceptionHasNoTransactionTokenContextImpl() {
-        try {
-            interceptor.afterCompletion(request, response, null,
-                    new Exception());
-        } catch (Exception e) {
-            fail();
-        }
-    }
 
-    /*
-     * @Test public void testCreateTokenSynchronization() throws Exception { int size = 2000; Thread arrThreads[] = new
-     * Thread[size]; for (int i = 0; i <size ; i++) { Thread thread = new Thread(new Runnable() {
-     * @Override public void run() { try { interceptor.createToken(request, session1, tokenInfo1, generator1, tokenStore1); }
-     * catch (Exception ex) { ex.printStackTrace(); } } }, "Thread_" + (i+1)); arrThreads[i] = thread; } for (Thread thread :
-     * arrThreads) { try { thread.start(); thread.join(); } catch (Exception e) { // TODO Auto-generated catch block
-     * e.printStackTrace(); } } }
-     */
+        interceptor.afterCompletion(request, response, null, new Exception());
+    }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/RequestUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/RequestUtilsTest.java
@@ -15,9 +15,9 @@
  */
 package org.terasoluna.gfw.web.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Constructor;
 
@@ -38,13 +38,13 @@ public class RequestUtilsTest {
     public void testIsAjaxRequest() {
         request.addHeader("X-Requested-With", "XMLHttpRequest");
 
-        assertTrue(RequestUtils.isAjaxRequest(request));
+        assertThat(RequestUtils.isAjaxRequest(request), is(true));
     }
 
     @Test
     public void testNotAjaxRequest() {
 
-        assertFalse(RequestUtils.isAjaxRequest(request));
+        assertThat(RequestUtils.isAjaxRequest(request), is(false));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class RequestUtilsTest {
         Constructor<RequestUtils> c = RequestUtils.class
                 .getDeclaredConstructor();
         c.setAccessible(true);
-        assertNotNull(c.newInstance());
+        assertThat(c.newInstance(), is(notNullValue()));
     }
 
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/ResponseUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/ResponseUtilsTest.java
@@ -18,12 +18,12 @@ package org.terasoluna.gfw.web.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.Constructor;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class ResponseUtilsTest {
@@ -44,14 +44,10 @@ public class ResponseUtilsTest {
                 "Thu, 01 Jan 1970 00:00:00 GMT")); // Changed by SPR-11912
     }
 
-    @Test
+    @Test(expected = None.class)
     public void testSetPreventionCachingHeadersWithNullResponse() {
-        try {
-            ResponseUtils.setPreventionCachingHeaders(null);
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            fail();
-        }
+
+        ResponseUtils.setPreventionCachingHeaders(null);
     }
 
     @Test


### PR DESCRIPTION
Please review #1017.

#### Changes Policy

* Corrected assertions what should be done in `Matcher` instead of `actual` (verification target).  
  However, the part that is intended to execute the  method itself of the test target class (ex. `equals`, `toString`) is not modified.
* Improved to use `assertThrows` where try-catch is used for exception assertion.
* Redundant assertions and tests combined to make it compact.