### PR TITLE
Update the plugin version of terasoluna-gfw-parent #1010

### DIFF
--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -521,7 +521,7 @@
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <cargo-maven2-plugin.version>1.8.2</cargo-maven2-plugin.version>
+    <cargo-maven2-plugin.version>1.8.4</cargo-maven2-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <!-- == Dependency Versions == -->

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -510,18 +510,18 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>2.9</maven-dependency-plugin.version>
-    <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-    <maven-source-plugin.version>2.4</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>2.10.1</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
-    <maven-assembly-plugin.version>2.5.1</maven-assembly-plugin.version>
-    <maven-clean-plugin.version>2.5</maven-clean-plugin.version>
-    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.4</maven-site-plugin.version>
-    <cargo-maven2-plugin.version>1.6.2</cargo-maven2-plugin.version>
+    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
+    <cargo-maven2-plugin.version>1.8.2</cargo-maven2-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <!-- == Dependency Versions == -->


### PR DESCRIPTION
Please review #1010.

Update the plugin version of terasoluna-gfw-parent.

Confirmation

- Confirmed that there is no Warning when building in GitLab.

- Confirmed that the upgrade of the plugin does not affect the operation.
  - `maven-assembly-plugin`：Confirmed that there is no warning when running `mvn package`.

  - `maven-clean-plugin`：Confirmed that the `target` directory is deleted when running `mvn clean install`.
  - `maven-compiler-plugin`：Confirmed that there is no warning when running `mvn compile`.
  - `maven-dependency-plugin`：Confirmed that no warning is printed when running `mvn dependency:tree`.
  - `maven-deploy-plugin`：Confirmed that the gitlab job successfully pushes to the snapshot repository.
  - `maven-install-plugin`：Confirmed that `mvn clean install` can add artifacts to the local repository without any warnings.
  - `maven-jar-plugin`：Confirmed that when running `mvn package`, the jar is generated without any warning.
  - `maven-javadoc-plugin`：Confirmed that no warnings etc. are displayed when running `mvn javadoc:javadoc` (but javadoc generation is skipped in this project).
  - `maven-site-plugin`：Confirmed that the project site is generated with `mvn site` (the version before the update gave an error and failed to generate the site).
  - `maven-source-plugin`：Ran `mvn package` and confirmed that the jar was successfully generated without any warnings.
  - `maven-resources-plugin`：Confirmed that resources are copied to the `target` directory when running `mvn package`.
  - `cargo-maven2-plugin`：Run `mvn cargo:run` on a project with `terasoluna-gfw-parent` as the parent pom, and confirmed that it can run successfully without warning.

