### PR TITLE
Compare support Bean Validation 2.0 #1044

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -16,14 +16,12 @@
 package org.terasoluna.gfw.common.validator.constraints;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -31,6 +29,7 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 import javax.validation.ValidationException;
 
+import org.terasoluna.gfw.common.validator.constraints.Compare.List;
 import org.terasoluna.gfw.common.validator.constraintvalidators.CompareValidator;
 
 /**
@@ -53,8 +52,9 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.CompareValidator
  */
 @Documented
 @Constraint(validatedBy = { CompareValidator.class })
-@Target({ TYPE, ANNOTATION_TYPE })
+@Target({ TYPE, ANNOTATION_TYPE, TYPE_USE })
 @Retention(RUNTIME)
+@Repeatable(List.class)
 public @interface Compare {
 
     /**
@@ -108,7 +108,7 @@ public @interface Compare {
      * @since 5.1.0
      */
     @Documented
-    @Target({ METHOD, FIELD, TYPE, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+    @Target({ TYPE, ANNOTATION_TYPE, TYPE_USE })
     @Retention(RUNTIME)
     @interface List {
         /**

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/CompareTest.java
@@ -15,12 +15,19 @@
  */
 package org.terasoluna.gfw.common.validator.constraints;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.beans.IntrospectionException;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Path.PropertyNode;
@@ -514,6 +521,75 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
     }
 
     /**
+     * all values in the collection are valid.
+     */
+    @Test
+    public void testCollectionValid() {
+        form.setListProperty(Arrays.asList(new Pair(100, 100),
+                new Pair(100, 100)));
+
+        violations = validator.validate(form);
+        assertThat(violations.size(), is(0));
+    }
+
+    /**
+     * first value in the collection is invalid.
+     */
+    @Test
+    public void testCollectionFirstInvalid() {
+        form.setListProperty(Arrays.asList(new Pair(101, 100),
+                new Pair(100, 100)));
+
+        violations = validator.validate(form);
+        assertThat(violations.size(), is(1));
+        assertThat(violations, contains(allOf( //
+                hasProperty("propertyPath", hasToString(
+                        "listProperty[0].<list element>.left")), //
+                hasProperty("message", is(String.format(
+                        MESSAGE_VALIDATION_ERROR, "left", "right"))))));
+    }
+
+    /**
+     * last value in the collection is invalid.
+     */
+    @Test
+    public void testCollectionLastInvalid() {
+        form.setListProperty(Arrays.asList(new Pair(100, 100),
+                new Pair(100, 101)));
+
+        violations = validator.validate(form);
+        assertThat(violations.size(), is(1));
+        assertThat(violations, contains(allOf( //
+                hasProperty("propertyPath", hasToString(
+                        "listProperty[1].<list element>.left")), //
+                hasProperty("message", is(String.format(
+                        MESSAGE_VALIDATION_ERROR, "left", "right"))))));
+    }
+
+    /**
+     * all values in the collection are invalid.
+     */
+    @Test
+    public void testCollectionAllInvalid() {
+        form.setListProperty(Arrays.asList(new Pair(101, 100),
+                new Pair(100, 101)));
+
+        violations = validator.validate(form);
+        assertThat(violations.size(), is(2));
+        assertThat(violations, containsInAnyOrder( //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "listProperty[0].<list element>.left")), //
+                        hasProperty("message", is(String.format(
+                                MESSAGE_VALIDATION_ERROR, "left", "right")))), //
+                allOf( //
+                        hasProperty("propertyPath", hasToString(
+                                "listProperty[1].<list element>.left")), //
+                        hasProperty("message", is(String.format(
+                                MESSAGE_VALIDATION_ERROR, "left", "right"))))));
+    }
+
+    /**
      * Validation group operator not equal.
      */
     private static interface NotEqual {
@@ -591,34 +667,33 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
     private static interface NotComparableLeft {
     };
 
-    @Compare.List({
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL),
-            @Compare(left = "left", right = "right", operator = Operator.NOT_EQUAL, groups = {
-                    NotEqual.class }),
-            @Compare(left = "left", right = "right", operator = Operator.GREATER_THAN_OR_EQUAL, groups = {
-                    GreaterThanOrEqual.class }),
-            @Compare(left = "left", right = "right", operator = Operator.GREATER_THAN, groups = {
-                    GreaterThan.class }),
-            @Compare(left = "left", right = "right", operator = Operator.LESS_THAN_OR_EQUAL, groups = {
-                    LessThanOrEqual.class }),
-            @Compare(left = "left", right = "right", operator = Operator.LESS_THAN, groups = {
-                    LessThan.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, requireBoth = true, groups = {
-                    RequireBoth.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, requireBoth = false, groups = {
-                    RequireEither.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.PROPERTY, groups = {
-                    NodeProperty.class }),
-            @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.ROOT_BEAN, groups = {
-                    PathRootBean.class }),
-            @Compare(left = "left", right = "stringProperty", operator = Operator.EQUAL, groups = {
-                    TypeUnmatch.class }),
-            @Compare(left = "unknown", right = "right", operator = Operator.EQUAL, groups = {
-                    UnknownLeft.class }),
-            @Compare(left = "left", right = "unknown", operator = Operator.EQUAL, groups = {
-                    UnknownRight.class }),
-            @Compare(left = "objectProperty", right = "right", operator = Operator.EQUAL, groups = {
-                    NotComparableLeft.class }) })
+    @Compare(left = "left", right = "right", operator = Operator.EQUAL)
+    @Compare(left = "left", right = "right", operator = Operator.NOT_EQUAL, groups = {
+            NotEqual.class })
+    @Compare(left = "left", right = "right", operator = Operator.GREATER_THAN_OR_EQUAL, groups = {
+            GreaterThanOrEqual.class })
+    @Compare(left = "left", right = "right", operator = Operator.GREATER_THAN, groups = {
+            GreaterThan.class })
+    @Compare(left = "left", right = "right", operator = Operator.LESS_THAN_OR_EQUAL, groups = {
+            LessThanOrEqual.class })
+    @Compare(left = "left", right = "right", operator = Operator.LESS_THAN, groups = {
+            LessThan.class })
+    @Compare(left = "left", right = "right", operator = Operator.EQUAL, requireBoth = true, groups = {
+            RequireBoth.class })
+    @Compare(left = "left", right = "right", operator = Operator.EQUAL, requireBoth = false, groups = {
+            RequireEither.class })
+    @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.PROPERTY, groups = {
+            NodeProperty.class })
+    @Compare(left = "left", right = "right", operator = Operator.EQUAL, node = Node.ROOT_BEAN, groups = {
+            PathRootBean.class })
+    @Compare(left = "left", right = "stringProperty", operator = Operator.EQUAL, groups = {
+            TypeUnmatch.class })
+    @Compare(left = "unknown", right = "right", operator = Operator.EQUAL, groups = {
+            UnknownLeft.class })
+    @Compare(left = "left", right = "unknown", operator = Operator.EQUAL, groups = {
+            UnknownRight.class })
+    @Compare(left = "objectProperty", right = "right", operator = Operator.EQUAL, groups = {
+            NotComparableLeft.class })
     public class CompareTestForm {
         private Integer left;
 
@@ -627,6 +702,8 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
         private String stringProperty;
 
         private Object objectProperty;
+
+        private List<@Compare(left = "left", right = "right", operator = Operator.EQUAL) Pair> listProperty;
 
         public Integer getLeft() {
             return left;
@@ -658,6 +735,41 @@ public class CompareTest extends AbstractConstraintsTest<CompareTestForm> {
 
         public void setObjectProperty(Object objectProperty) {
             this.objectProperty = objectProperty;
+        }
+
+        public List<Pair> getListProperty() {
+            return listProperty;
+        }
+
+        public void setListProperty(List<Pair> listProperty) {
+            this.listProperty = listProperty;
+        }
+    }
+
+    public static class Pair {
+        private Integer left;
+
+        private Integer right;
+
+        public Pair(Integer left, Integer right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        public Integer getLeft() {
+            return left;
+        }
+
+        public void setLeft(Integer left) {
+            this.left = left;
+        }
+
+        public Integer getRight() {
+            return right;
+        }
+
+        public void setRight(Integer right) {
+            this.right = right;
         }
     }
 }


### PR DESCRIPTION
(cherry picked from commit 047bcf45510d30cafd66129a033cf3dc53ca0f1e)

Please review #1044

Conflicts have occurred for the following reasons:
- `org.junit.Assert.assertThat` was used instead of `org.hamcrest.MatcherAssert.assertThat` because #992 wasn't backported
->Since Spring Boot 2.4.0. Is not used in 5.6.x, I decided to use  `org.junit.Assert.assertThat` according to the original description.
- Class CompareTestForm wasn't static because #996 wasn't backported
->Since it doesn't have to be static, static is not used according to the original description.

Checklist:
- I ran CompareTest.java on eclipse and confirmed that everything was successful.
- Confirmed that it can be built with GitLab