### PR TITLE
update the plugin version #1083

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,13 @@
   </scm>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-    <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
-    <license-maven-plugin.version>4.1</license-maven-plugin.version>
-    <coveralls-maven-plugin.version>4.1.0</coveralls-maven-plugin.version>
-    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+    <org.jacoco.jacoco-maven-plugin.version>0.8.7</org.jacoco.jacoco-maven-plugin.version>
+    <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
+    <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+    <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>
+    <org.eluder.coveralls.coveralls-maven-plugin.version>4.1.0</org.eluder.coveralls.coveralls-maven-plugin.version>
+    <org.apache.maven.plugins.maven-gpg-plugin.version>3.0.1</org.apache.maven.plugins.maven-gpg-plugin.version>
+    <org.sonatype.plugins.nexus-staging-maven-plugin.version>1.6.8</org.sonatype.plugins.nexus-staging-maven-plugin.version>
     <!-- == Project Properties == -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.deploy.skip>true</maven.deploy.skip>
@@ -81,7 +81,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>${maven-gpg-plugin.version}</version>
+            <version>${org.apache.maven.plugins.maven-gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -101,7 +101,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>${org.sonatype.plugins.nexus-staging-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -133,7 +133,7 @@
             <plugin>
               <groupId>org.jacoco</groupId>
               <artifactId>jacoco-maven-plugin</artifactId>
-              <version>${jacoco-maven-plugin.version}</version>
+              <version>${org.jacoco.jacoco-maven-plugin.version}</version>
               <configuration>
                 <skip>true</skip>
               </configuration>
@@ -141,12 +141,12 @@
             <plugin>
               <groupId>com.mycila</groupId>
               <artifactId>license-maven-plugin</artifactId>
-              <version>${license-maven-plugin.version}</version>
+              <version>${com.mycila.license-maven-plugin.version}</version>
             </plugin>
             <plugin>
               <groupId>net.revelc.code.formatter</groupId>
               <artifactId>formatter-maven-plugin</artifactId>
-              <version>${formatter-maven-plugin.version}</version>
+              <version>${net.revelc.code.formatter.formatter-maven-plugin.version}</version>
               <configuration>
                 <configFile>${project.basedir}/eclipse/formatter.xml
                 </configFile>
@@ -167,7 +167,7 @@
             <plugin>
               <groupId>org.eluder.coveralls</groupId>
               <artifactId>coveralls-maven-plugin</artifactId>
-              <version>${coveralls-maven-plugin.version}</version>
+              <version>${org.eluder.coveralls.coveralls-maven-plugin.version}</version>
               <configuration>
                 <jacocoReports>
                   <jacocoReport>terasoluna-gfw-common-libraries/terasoluna-gfw-common/target/site/jacoco/jacoco.xml</jacocoReport>
@@ -207,7 +207,7 @@
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>xml-maven-plugin</artifactId>
-              <version>${xml-maven-plugin.version}</version>
+              <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
               <configuration>
                 <indentSize>2</indentSize>
                 <formatFileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
   </scm>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
-    <formatter-maven-plugin.version>2.0.1</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>
-    <com.google.code.maven-license-plugin.version>1.4.0</com.google.code.maven-license-plugin.version>
+    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+    <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
+    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
+    <license-maven-plugin.version>4.1</license-maven-plugin.version>
     <coveralls-maven-plugin.version>4.1.0</coveralls-maven-plugin.version>
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <!-- == Project Properties == -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -89,6 +89,12 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -133,9 +139,9 @@
               </configuration>
             </plugin>
             <plugin>
-              <groupId>com.google.code.maven-license-plugin</groupId>
-              <artifactId>maven-license-plugin</artifactId>
-              <version>${com.google.code.maven-license-plugin.version}</version>
+              <groupId>com.mycila</groupId>
+              <artifactId>license-maven-plugin</artifactId>
+              <version>${license-maven-plugin.version}</version>
             </plugin>
             <plugin>
               <groupId>net.revelc.code.formatter</groupId>

--- a/terasoluna-gfw-common-libraries/pom.xml
+++ b/terasoluna-gfw-common-libraries/pom.xml
@@ -73,9 +73,9 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>com.google.code.maven-license-plugin</groupId>
-          <artifactId>maven-license-plugin</artifactId>
-          <version>${com.google.code.maven-license-plugin.version}</version>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license-maven-plugin.version}</version>
           <configuration>
             <header>${project.root.basedir}/../license/header.txt</header>
             <includes>
@@ -118,11 +118,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>${maven-antrun-plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>org.eluder.coveralls</groupId>
           <artifactId>coveralls-maven-plugin</artifactId>
           <version>${coveralls-maven-plugin.version}</version>
@@ -154,12 +149,11 @@
   </build>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
-    <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
-    <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
-    <com.google.code.maven-license-plugin.version>1.4.0</com.google.code.maven-license-plugin.version>
-    <formatter-maven-plugin.version>2.0.1</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+    <license-maven-plugin.version>4.1</license-maven-plugin.version>
+    <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
+    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
     <coveralls-maven-plugin.version>4.1.0</coveralls-maven-plugin.version>
     <!-- == Project Properties == -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/terasoluna-gfw-common-libraries/pom.xml
+++ b/terasoluna-gfw-common-libraries/pom.xml
@@ -44,7 +44,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${maven-surefire-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-surefire-plugin.version}</version>
           <configuration>
             <includes>
               <include>**/*Test.java</include>
@@ -55,7 +55,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>${jacoco-maven-plugin.version}</version>
+          <version>${org.jacoco.jacoco-maven-plugin.version}</version>
           <executions>
             <execution>
               <id>prepare-agent</id>
@@ -75,7 +75,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>${license-maven-plugin.version}</version>
+          <version>${com.mycila.license-maven-plugin.version}</version>
           <configuration>
             <header>${project.root.basedir}/../license/header.txt</header>
             <includes>
@@ -91,7 +91,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>${formatter-maven-plugin.version}</version>
+          <version>${net.revelc.code.formatter.formatter-maven-plugin.version}</version>
           <configuration>
             <configFile>${project.root.basedir}/../eclipse/formatter.xml
             </configFile>
@@ -112,7 +112,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
-          <version>${xml-maven-plugin.version}</version>
+          <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
           <configuration>
             <indentSize>2</indentSize>
           </configuration>
@@ -120,7 +120,7 @@
         <plugin>
           <groupId>org.eluder.coveralls</groupId>
           <artifactId>coveralls-maven-plugin</artifactId>
-          <version>${coveralls-maven-plugin.version}</version>
+          <version>${org.eluder.coveralls.coveralls-maven-plugin.version}</version>
           <configuration>
             <jacocoReports>
               <jacocoReport>terasoluna-gfw-common/target/site/jacoco/jacoco.xml</jacocoReport>
@@ -149,12 +149,12 @@
   </build>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-    <license-maven-plugin.version>4.1</license-maven-plugin.version>
-    <formatter-maven-plugin.version>2.15.0</formatter-maven-plugin.version>
-    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
-    <coveralls-maven-plugin.version>4.1.0</coveralls-maven-plugin.version>
+    <org.apache.maven.plugins.maven-surefire-plugin.version>3.0.0-M5</org.apache.maven.plugins.maven-surefire-plugin.version>
+    <org.jacoco.jacoco-maven-plugin.version>0.8.7</org.jacoco.jacoco-maven-plugin.version>
+    <com.mycila.license-maven-plugin.version>4.1</com.mycila.license-maven-plugin.version>
+    <net.revelc.code.formatter.formatter-maven-plugin.version>2.15.0</net.revelc.code.formatter.formatter-maven-plugin.version>
+    <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+    <org.eluder.coveralls.coveralls-maven-plugin.version>4.1.0</org.eluder.coveralls.coveralls-maven-plugin.version>
     <!-- == Project Properties == -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <archetype.test.skip>true</archetype.test.skip>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0201/pom.xml
@@ -50,8 +50,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208/pom.xml
@@ -50,8 +50,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208kanji/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0208kanji/pom.xml
@@ -50,8 +50,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0213kanji/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/catalog/terasoluna-gfw-codepoints-jisx0213kanji/pom.xml
@@ -50,8 +50,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-security-web/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-security-web/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-string/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-string/pom.xml
@@ -61,8 +61,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/pom.xml
@@ -69,8 +69,8 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/pom.xml
@@ -55,8 +55,8 @@
         <artifactId>formatter-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/terasoluna-gfw-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/pom.xml
@@ -42,7 +42,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>xml-maven-plugin</artifactId>
-          <version>${xml-maven-plugin.version}</version>
+          <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
           <configuration>
             <indentSize>2</indentSize>
           </configuration>
@@ -52,6 +52,6 @@
   </build>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
+    <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
   </properties>
 </project>

--- a/terasoluna-gfw-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/pom.xml
@@ -52,6 +52,6 @@
   </build>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <xml-maven-plugin.version>1.0.1</xml-maven-plugin.version>
+    <xml-maven-plugin.version>1.0.2</xml-maven-plugin.version>
   </properties>
 </project>

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -40,6 +40,15 @@
     <developerConnection>scm:git:git@github.com:terasolunaorg/terasoluna-gfw.git</developerConnection>
     <url>git@github.com:terasolunaorg/terasoluna-gfw.git</url>
   </scm>
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>${maven-project-info-reports-plugin.version}</version>
+      </plugin>
+    </plugins>
+  </reporting>
   <build>
     <pluginManagement>
       <plugins>
@@ -156,8 +165,8 @@
         </plugin>
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
-          <artifactId>cargo-maven2-plugin</artifactId>
-          <version>${cargo-maven2-plugin.version}</version>
+          <artifactId>cargo-maven3-plugin</artifactId>
+          <version>${cargo-maven3-plugin.version}</version>
           <configuration>
             <configuration>
               <properties>
@@ -511,19 +520,20 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
+    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
     <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <cargo-maven2-plugin.version>1.8.4</cargo-maven2-plugin.version>
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+    <cargo-maven3-plugin.version>1.9.5</cargo-maven3-plugin.version>
+    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <!-- == TERASOLUNA == -->
@@ -605,6 +615,12 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>${maven-project-info-reports-plugin.version}</version>
+        <version>${org.apache.maven.plugins.maven-project-info-reports-plugin.version}</version>
       </plugin>
     </plugins>
   </reporting>
@@ -55,7 +55,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-compiler-plugin.version}</version>
           <configuration>
             <source>${java-version}</source>
             <target>${java-version}</target>
@@ -64,7 +64,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>${maven-dependency-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-dependency-plugin.version}</version>
           <executions>
             <execution>
               <id>install</id>
@@ -78,7 +78,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>${maven-resources-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-resources-plugin.version}</version>
           <configuration>
             <encoding>${encoding}</encoding>
           </configuration>
@@ -86,7 +86,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>${maven-source-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-source-plugin.version}</version>
           <executions>
             <execution>
               <id>source-jar</id>
@@ -105,7 +105,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven-javadoc-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-javadoc-plugin.version}</version>
           <configuration>
             <encoding>${encoding}</encoding>
             <docencoding>${encoding}</docencoding>
@@ -128,7 +128,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>${maven-jar-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-jar-plugin.version}</version>
           <configuration>
             <archive>
               <addMavenDescriptor>false</addMavenDescriptor>
@@ -141,32 +141,32 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>${maven-assembly-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-assembly-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>${maven-clean-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-clean-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>${maven-install-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-install-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>${maven-deploy-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-deploy-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>${maven-site-plugin.version}</version>
+          <version>${org.apache.maven.plugins.maven-site-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven3-plugin</artifactId>
-          <version>${cargo-maven3-plugin.version}</version>
+          <version>${org.codehaus.cargo.cargo-maven3-plugin.version}</version>
           <configuration>
             <configuration>
               <properties>
@@ -520,21 +520,21 @@
   </dependencyManagement>
   <properties>
     <!-- == Maven Plugin Versions == -->
-    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
-    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-    <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-    <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-    <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
-    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
-    <cargo-maven3-plugin.version>1.9.5</cargo-maven3-plugin.version>
-    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-    <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+    <org.apache.maven.plugins.maven-project-info-reports-plugin.version>3.1.2</org.apache.maven.plugins.maven-project-info-reports-plugin.version>
+    <org.apache.maven.plugins.maven-compiler-plugin.version>3.8.1</org.apache.maven.plugins.maven-compiler-plugin.version>
+    <org.apache.maven.plugins.maven-dependency-plugin.version>3.2.0</org.apache.maven.plugins.maven-dependency-plugin.version>
+    <org.apache.maven.plugins.maven-resources-plugin.version>3.2.0</org.apache.maven.plugins.maven-resources-plugin.version>
+    <org.apache.maven.plugins.maven-source-plugin.version>3.2.1</org.apache.maven.plugins.maven-source-plugin.version>
+    <org.apache.maven.plugins.maven-javadoc-plugin.version>3.3.0</org.apache.maven.plugins.maven-javadoc-plugin.version>
+    <org.apache.maven.plugins.maven-jar-plugin.version>3.2.0</org.apache.maven.plugins.maven-jar-plugin.version>
+    <org.apache.maven.plugins.maven-assembly-plugin.version>3.3.0</org.apache.maven.plugins.maven-assembly-plugin.version>
+    <org.apache.maven.plugins.maven-clean-plugin.version>3.1.0</org.apache.maven.plugins.maven-clean-plugin.version>
+    <org.apache.maven.plugins.maven-install-plugin.version>3.0.0-M1</org.apache.maven.plugins.maven-install-plugin.version>
+    <org.apache.maven.plugins.maven-deploy-plugin.version>3.0.0-M1</org.apache.maven.plugins.maven-deploy-plugin.version>
+    <org.apache.maven.plugins.maven-site-plugin.version>3.9.1</org.apache.maven.plugins.maven-site-plugin.version>
+    <org.codehaus.cargo.cargo-maven3-plugin.version>1.9.5</org.codehaus.cargo.cargo-maven3-plugin.version>
+    <org.apache.maven.plugins.maven-gpg-plugin.version>3.0.1</org.apache.maven.plugins.maven-gpg-plugin.version>
+    <org.sonatype.plugins.nexus-staging-maven-plugin.version>1.6.8</org.sonatype.plugins.nexus-staging-maven-plugin.version>
     <!-- == Dependency Versions == -->
     <!-- == TERASOLUNA == -->
     <terasoluna.gfw.version>5.8.0-SNAPSHOT</terasoluna.gfw.version>
@@ -607,7 +607,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>${maven-gpg-plugin.version}</version>
+            <version>${org.apache.maven.plugins.maven-gpg-plugin.version}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -627,7 +627,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <version>${org.sonatype.plugins.nexus-staging-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
Please review #1083

Confirmation is done with maven 3.8.1.

The changes other than the version upgrade are as follows:
- The latest version of coveralls-maven-plugin is 4.3.0, but since travis is currently unavailable, the version upgrade is on hold.
- Due to the version upgrade of formatter-maven-plugin, the format of javadoc comments will change, but #1084 will handle this.
- The `com.google.code:maven-license-plugin` has been changed to `com.mycila:license-maven-plugin` as in #600.
- Added settings required for importing private key in maven 3.8.1 to maven-gpg-plugin
- The maven-antrun-plugin should have been originally defined in terasoluna-gfw-parent, but it was defined in terasoluna-gfw-common-libraries and was not used by anyone, so I deleted it.
- When executing `mvn site`, a warning will be issued if the version of maven-project-info-reports-plugin is not specified, so I defined it in the reporting element.
- cargo-maven2-plugin has been renamed to cargo-maven3-plugin since 1.9.0
https://codehaus-cargo.github.io/cargo/Maven+3+Plugin.html
- Fixed the variable name of the plugin version to be `groupId.artifactId.pugin.version`.
https://github.com/terasolunaorg/terasoluna-gfw/commit/7fefb36894aa7c7a76d1056635ff2c2cad40f1ce