### PR TITLE
modify formatter.xml and format source code #1084

### DIFF
--- a/eclipse/formatter.xml
+++ b/eclipse/formatter.xml
@@ -1,313 +1,390 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<profiles version="12">
-<profile kind="CodeFormatterProfile" name="TERASOLUNA Framework Team" version="12">
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="128"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="18"/>
-<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="18"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="18"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="80"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
-</profile>
+<profiles version="21">
+    <profile kind="CodeFormatterProfile" name="TERASOLUNA Framework Team" version="21">
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="49"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assertion_message" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="18"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_record_declaration" value="18"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="18"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="18"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_annotations" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_constructor" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_record_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="128"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_record_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_record_components" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_record_components" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_constructor" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_record_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_record_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_record_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assertion_message_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="false"/>
+    </profile>
 </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -158,10 +158,6 @@
                   <include>**/src/main/java/**/*.java</include>
                   <include>**/src/test/java/**/*.java</include>
                 </includes>
-                <excludes>
-                  <exclude>terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalf.java</exclude>
-                  <exclude>terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalfCodePointsMap.java</exclude>
-                </excludes>
               </configuration>
             </plugin>
             <plugin>

--- a/terasoluna-gfw-common-libraries/pom.xml
+++ b/terasoluna-gfw-common-libraries/pom.xml
@@ -103,10 +103,6 @@
               <include>**/src/main/java/**/*.java</include>
               <include>**/src/test/java/**/*.java</include>
             </includes>
-            <excludes>
-              <exclude>terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalf.java</exclude>
-              <exclude>terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalfCodePointsMap.java</exclude>
-            </excludes>
           </configuration>
         </plugin>
         <plugin>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/CodePoints.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/main/java/org/terasoluna/gfw/common/codepoints/CodePoints.java
@@ -191,6 +191,7 @@ import java.util.concurrent.ConcurrentMap;
  *   }
  * }</code>
  * </pre>
+ * 
  * @since 5.1.0
  */
 public class CodePoints implements Serializable {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeList.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/NumberRangeCodeList.java
@@ -139,7 +139,7 @@ public class NumberRangeCodeList extends AbstractCodeList implements
     }
 
     /**
-     * Gets the display format of the value part of the codelist 
+     * Gets the display format of the value part of the codelist
      * @return valueFormat format string for code value
      */
     public String getValueFormat() {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/ReloadableI18nCodeList.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/ReloadableI18nCodeList.java
@@ -19,7 +19,6 @@ import org.terasoluna.gfw.common.codelist.ReloadableCodeList;
 
 /**
  * Adds Reloadable support to {@link I18nCodeList}
- *
  * @since 5.4.2
  */
 public interface ReloadableI18nCodeList extends I18nCodeList,

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/SimpleReloadableI18nCodeList.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/SimpleReloadableI18nCodeList.java
@@ -41,8 +41,6 @@ import com.google.common.collect.Tables;
  * <p>
  * To build a table of codelist, set a map of the {@link Locale} and the corresponding {@link ReloadableCodeList}.<br>
  * </p>
- *
- *
  * <h3>set by rows with {@link ReloadableCodeList}</h3>
  *
  * <pre>
@@ -75,7 +73,6 @@ import com.google.common.collect.Tables;
  *     &lt;property name=&quot;valueColumn&quot; value=&quot;code&quot; /&gt;
  *     &lt;property name=&quot;labelColumn&quot; value=&quot;label&quot; /&gt;
  * &lt;/bean&gt;
- *
  * </pre>
  *
  * @since 5.4.2

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/i18n/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Classes related to internationalization support of {@code CodeList} functionality
- *
  */
 package org.terasoluna.gfw.common.codelist.i18n;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/codelist/package-info.java
@@ -19,6 +19,5 @@
  * <pre>
  * Package for CodeList functionality
  * </pre>
- *
  */
 package org.terasoluna.gfw.common.codelist;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/ClassicDateFactory.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/ClassicDateFactory.java
@@ -24,14 +24,10 @@ import java.sql.Timestamp;
  * create current system date as
  * </p>
  * <ul>
- * <li>
- * {@link java.util.Date}</li>
- * <li>
- * {@link java.sql.Date}</li>
- * <li>
- * {@link java.sql.Timestamp}</li>
- * <li>
- * {@link java.sql.Time}</li>
+ * <li>{@link java.util.Date}</li>
+ * <li>{@link java.sql.Date}</li>
+ * <li>{@link java.sql.Timestamp}</li>
+ * <li>{@link java.sql.Time}</li>
  * </ul>
  * @since 5.0.0
  */

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/date/package-info.java
@@ -15,7 +15,5 @@
  */
 /**
  * date package.
- *
- *
  */
 package org.terasoluna.gfw.common.date;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/exception/package-info.java
@@ -14,8 +14,6 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Package containing functionality for handling exceptions that occur 
- * in logic under Spring MVC
- *
+ * Package containing functionality for handling exceptions that occur in logic under Spring MVC
  */
 package org.terasoluna.gfw.common.exception;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/message/package-info.java
@@ -14,8 +14,6 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Package for class that provide Message management functionality for 
- * messages displayed on screen or in reports.
- *
+ * Package for class that provide Message management functionality for messages displayed on screen or in reports.
  */
 package org.terasoluna.gfw.common.message;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/QueryEscapeUtils.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/QueryEscapeUtils.java
@@ -177,6 +177,7 @@ public final class QueryEscapeUtils {
      * withFullWidth().toLikeCondition(null)   -&gt; null
      * </code>
      * </pre>
+     * 
      * @return LikeConditionEscape that escape full-width wildcards.
      * @since 1.0.2
      */

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/query/package-info.java
@@ -16,6 +16,5 @@
 /**
  * Package that contains classes to process the database query string <br>
  * For Ex. Escaping the query string.
- *
  */
 package org.terasoluna.gfw.common.query;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/sequencer/package-info.java
@@ -14,8 +14,6 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Package that contains classes that provide functionality to generate sequences.
- * For Ex: primary key of database table.
- *
+ * Package that contains classes that provide functionality to generate sequences. For Ex: primary key of database table.
  */
 package org.terasoluna.gfw.common.sequencer;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/JdbcCodeListTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/codelist/JdbcCodeListTest.java
@@ -117,7 +117,7 @@ public class JdbcCodeListTest {
     }
 
     /**
-     * check retrieveMap method.　Setting jdbcTemplate instead of dataSource.
+     * check retrieveMap method. Setting jdbcTemplate instead of dataSource.
      */
     @Test
     public void testRetrieveMap03() {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/query/QueryEscapeUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/query/QueryEscapeUtilsTest.java
@@ -236,17 +236,23 @@ public class QueryEscapeUtilsTest {
                     ? new StringBuilder()
                     : new StringBuilder(expectedToLikeConditionWithFullWidth);
             this.expectedStartingWithCondition = (expectedToLikeCondition == null)
-                    ? null : expectedToLikeCondition + "%";
+                    ? null
+                    : expectedToLikeCondition + "%";
             this.expectedStartingWithConditionWithFullWidth = (expectedToLikeConditionWithFullWidth == null)
-                    ? null : expectedToLikeConditionWithFullWidth + "%";
+                    ? null
+                    : expectedToLikeConditionWithFullWidth + "%";
             this.expectedEndingWithCondition = (expectedToLikeCondition == null)
-                    ? null : "%" + expectedToLikeCondition;
+                    ? null
+                    : "%" + expectedToLikeCondition;
             this.expectedEndingWithConditionWithFullWidth = (expectedToLikeConditionWithFullWidth == null)
-                    ? null : "%" + expectedToLikeConditionWithFullWidth;
+                    ? null
+                    : "%" + expectedToLikeConditionWithFullWidth;
             this.expectedContainingCondition = (expectedToLikeCondition == null)
-                    ? null : "%" + expectedToLikeCondition + "%";
+                    ? null
+                    : "%" + expectedToLikeCondition + "%";
             this.expectedContainingConditionWithFullWidth = (expectedToLikeConditionWithFullWidth == null)
-                    ? null : "%" + expectedToLikeConditionWithFullWidth + "%";
+                    ? null
+                    : "%" + expectedToLikeConditionWithFullWidth + "%";
             this.expectedToLikeConditionIsNull = (expectedToLikeCondition == null)
                     ? new StringBuilder()
                     : new StringBuilder(expectedToLikeCondition);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateFactory.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateFactory.java
@@ -23,16 +23,11 @@ import org.terasoluna.gfw.common.date.ClassicDateFactory;
  * create current system date as
  * </p>
  * <ul>
- * <li>
- * {@link org.joda.time.DateTime}</li>
- * <li>
- * {@link java.util.Date}</li>
- * <li>
- * {@link java.sql.Date}</li>
- * <li>
- * {@link java.sql.Timestamp}</li>
- * <li>
- * {@link java.sql.Time}</li>
+ * <li>{@link org.joda.time.DateTime}</li>
+ * <li>{@link java.util.Date}</li>
+ * <li>{@link java.sql.Date}</li>
+ * <li>{@link java.sql.Timestamp}</li>
+ * <li>{@link java.sql.Time}</li>
  * </ul>
  * @since 5.0.0
  */

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateTimeFactory.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/main/java/org/terasoluna/gfw/common/date/jodatime/JodaTimeDateTimeFactory.java
@@ -23,8 +23,7 @@ import org.joda.time.DateTime;
  * create current system date as
  * </p>
  * <ul>
- * <li>
- * {@link org.joda.time.DateTime}</li>
+ * <li>{@link org.joda.time.DateTime}</li>
  * </ul>
  * @since 5.0.0
  */

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalf.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/main/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalf.java
@@ -765,7 +765,7 @@ package org.terasoluna.gfw.common.fullhalf;
  * <td>ﾟ</td>
  * </tr>
  * <tr>
- * <td>　</td>
+ * <td></td>
  * <td>&nbsp;</td>
  * </tr>
  * </table>
@@ -786,6 +786,7 @@ public final class DefaultFullHalf {
      * a singleton instance with default mapping table.
      * @see DefaultFullHalf
      */
+    // @formatter:off
     public static final FullHalfConverter INSTANCE = new FullHalfConverter(
             new FullHalfPairsBuilder()
                 .pair("！", "!")
@@ -975,4 +976,5 @@ public final class DefaultFullHalf {
                 .pair("゜", "ﾟ")
                 .pair("　", " ")
                 .build());
+    // @formatter:on
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalfCodePointsMap.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalfCodePointsMap.java
@@ -18,7 +18,7 @@ package org.terasoluna.gfw.common.fullhalf;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultFullHalfCodePointsMap extends
-                                       ConcurrentHashMap<String, String> {
+                                          ConcurrentHashMap<String, String> {
 
     private static final long serialVersionUID = 1L;
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMax.java
@@ -49,9 +49,9 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.ByteMaxValidator
  * </ul>
  * <p>
  * {@code null} elements are considered valid. Determine the byte length By encoding the string in the specified
- * {@link ByteMax#charset()}. If not specify, encode with charset {@code "UTF-8"}.
- * An {@link IllegalArgumentException}(wrapped in {@link ValidationException}) is thrown if specify
- * {@link ByteMax#charset()} that can not be used or specify {@link ByteMax#value()} that is negative value.
+ * {@link ByteMax#charset()}. If not specify, encode with charset {@code "UTF-8"}. An {@link IllegalArgumentException}(wrapped
+ * in {@link ValidationException}) is thrown if specify {@link ByteMax#charset()} that can not be used or specify
+ * {@link ByteMax#value()} that is negative value.
  * </p>
  * @since 5.1.0
  * @see ByteMaxValidator

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteMin.java
@@ -49,9 +49,9 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.ByteMinValidator
  * </ul>
  * <p>
  * {@code null} elements are considered valid. Determine the byte length By encoding the string in the specified
- * {@link ByteMin#charset()}. If not specify, encode with charset {@code "UTF-8"}.
- * An {@link IllegalArgumentException}(wrapped in {@link ValidationException}) is thrown if specify
- * {@link ByteMin#charset()} that can not be used or specify {@link ByteMin#value()} that is negative value.
+ * {@link ByteMin#charset()}. If not specify, encode with charset {@code "UTF-8"}. An {@link IllegalArgumentException}(wrapped
+ * in {@link ValidationException}) is thrown if specify {@link ByteMin#charset()} that can not be used or specify
+ * {@link ByteMin#value()} that is negative value.
  * </p>
  * @since 5.1.0
  * @see ByteMinValidator

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteSize.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/ByteSize.java
@@ -39,8 +39,8 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.ByteSizeValidato
  * The annotated element must be a {@link CharSequence}({@link String}, {@link StringBuilder}, etc ...) whose byte length must
  * be between the specified minimum and maximum.
  * <p>
- * This is an annotation combining the functions {@link ByteMin} and {@link ByteMax}. Compared to using two annotations,
- * the advantage is that overhead can be reduced by getting byte length at a time.
+ * This is an annotation combining the functions {@link ByteMin} and {@link ByteMax}. Compared to using two annotations, the
+ * advantage is that overhead can be reduced by getting byte length at a time.
  * </p>
  * <p>
  * Supported types are:
@@ -50,10 +50,10 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.ByteSizeValidato
  * </ul>
  * <p>
  * {@code null} elements are considered valid. Determine the byte length By encoding the string in the specified
- * {@link ByteSize#charset()}. If not specify, encode with charset {@code "UTF-8"}.
- * An {@link IllegalArgumentException}(wrapped in {@link ValidationException}) is thrown if specify
- * {@link ByteSize#charset()} that can not be used or specify {@link ByteSize#min()} or {@link ByteSize#max()}
- * that is negative or specify {@link ByteSize#max()} that lower than {@link ByteSize#min()} value.
+ * {@link ByteSize#charset()}. If not specify, encode with charset {@code "UTF-8"}. An {@link IllegalArgumentException}(wrapped
+ * in {@link ValidationException}) is thrown if specify {@link ByteSize#charset()} that can not be used or specify
+ * {@link ByteSize#min()} or {@link ByteSize#max()} that is negative or specify {@link ByteSize#max()} that lower than
+ * {@link ByteSize#min()} value.
  * </p>
  * @since 5.4.2
  * @see ByteSizeValidator

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/Compare.java
@@ -43,8 +43,8 @@ import org.terasoluna.gfw.common.validator.constraintvalidators.CompareValidator
  * </ul>
  * <p>
  * {@code null} elements are considered valid. If any of the specified two properties is {@code null}, are considered valid. If
- * specify two properties of different types, are considered invalid.
- * An {@link IllegalArgumentException}(wrapped in {@link ValidationException}) is thrown if specify a property not {@link Comparable}.
+ * specify two properties of different types, are considered invalid. An {@link IllegalArgumentException}(wrapped in
+ * {@link ValidationException}) is thrown if specify a property not {@link Comparable}.
  * </p>
  * @since 5.1.0
  * @see CompareValidator

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraints/package-info.java
@@ -15,7 +15,6 @@
  */
 /**
  * Constraint annotations for validating a any object using Bean Validation functionality.
- *
  * @since 5.1.0
  */
 package org.terasoluna.gfw.common.validator.constraints;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ByteSizeValidator.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/ByteSizeValidator.java
@@ -85,7 +85,8 @@ public class ByteSizeValidator implements
      * Validate execute.
      * @param value object to validate
      * @param context context in which the constraint is evaluated
-     * @return {@code true} if {@code value} length is between the specified minimum and maximum, or null. otherwise {@code false}.
+     * @return {@code true} if {@code value} length is between the specified minimum and maximum, or null. otherwise
+     *         {@code false}.
      * @see javax.validation.ConstraintValidator#isValid(java.lang.Object, javax.validation.ConstraintValidatorContext)
      */
     @Override

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/constraintvalidators/package-info.java
@@ -15,7 +15,6 @@
  */
 /**
  * Validator implementations for validating a object or simple value using Bean Validation functionality.
- *
  * @since 5.1.0
  */
 package org.terasoluna.gfw.common.validator.constraintvalidators;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/main/java/org/terasoluna/gfw/common/validator/package-info.java
@@ -15,7 +15,6 @@
  */
 /**
  * Validation functionality.
- *
  * @since 5.1.0
  */
 package org.terasoluna.gfw.common.validator;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteSizeTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraints/ByteSizeTest.java
@@ -180,7 +180,8 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
     }
 
     /**
-     * not specify min and max. expected valid if input value encoded in UTF-8 is between {@code 0} and {@link Long#MAX_VALUE} value.
+     * not specify min and max. expected valid if input value encoded in UTF-8 is between {@code 0} and {@link Long#MAX_VALUE}
+     * value.
      */
     @Test
     public void testSpecifyNotSpecifyMinAndMax() {
@@ -258,9 +259,9 @@ public class ByteSizeTest extends AbstractConstraintsTest<ByteSizeTestForm> {
     }
 
     /**
-     * specify max lower than min value. expected {@code ValidationException} caused by {@code IllegalArgumentException} that message is
-     * {@code failed to initialize validator by invalid argument} and nested by {@code IllegalArgumentException} that message is
-     * {@code max[2] must be higher or equal to min[3].}.
+     * specify max lower than min value. expected {@code ValidationException} caused by {@code IllegalArgumentException} that
+     * message is {@code failed to initialize validator by invalid argument} and nested by {@code IllegalArgumentException} that
+     * message is {@code max[2] must be higher or equal to min[3].}.
      */
     @Test
     public void testAnnotateMaxLowerThanMinValue() {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/MessagesPanelTag.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/MessagesPanelTag.java
@@ -35,7 +35,8 @@ import org.terasoluna.gfw.web.util.JspTagUtils;
 /**
  * Tag for displaying messages in panel format in JSP page<br>
  * <p>
- * Creates display tag, converts the object which is set in {@code pageContext} to String and sets this string inside the tag <br>
+ * Creates display tag, converts the object which is set in {@code pageContext} to String and sets this string inside the tag
+ * <br>
  * This tag displays the contents of {@code org.terasoluna.gfw.common.message.ResultMessages} by default. However,
  * {@code String} or {@code List<string>} set in {@code Model} can also be displayed using this tag
  * </p>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/message/package-info.java
@@ -16,6 +16,5 @@
 /**
  * Contains class to provide Message Management functionality on the web layer. <br>
  * Mainly deals with the display of messages in View.
- * 
  */
 package org.terasoluna.gfw.web.message;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/PaginationTag.java
@@ -262,20 +262,24 @@ public class PaginationTag extends RequestContextAwareTag {
         if (info.isFirstPage()) {
             if (StringUtils.hasText(firstLinkText)) {
                 // write first link
-                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref, firstLinkText);
+                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref,
+                        firstLinkText);
             }
             if (StringUtils.hasText(previousLinkText)) {
                 // write previous link
-                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref, previousLinkText);
+                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref,
+                        previousLinkText);
             }
         } else {
             if (StringUtils.hasText(firstLinkText)) {
                 // write first link
-                writeListItemAndAnchor(innerElementClass, tagWriter, info.getFirstUrl(), firstLinkText);
+                writeListItemAndAnchor(innerElementClass, tagWriter, info
+                        .getFirstUrl(), firstLinkText);
             }
             if (StringUtils.hasText(previousLinkText)) {
                 // write previous link
-                writeListItemAndAnchor(innerElementClass, tagWriter, info.getPreviousUrl(), previousLinkText);
+                writeListItemAndAnchor(innerElementClass, tagWriter, info
+                        .getPreviousUrl(), previousLinkText);
             }
         }
     }
@@ -291,20 +295,24 @@ public class PaginationTag extends RequestContextAwareTag {
         if (info.isLastPage()) {
             if (StringUtils.hasText(nextLinkText)) {
                 // write next link
-                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref, nextLinkText);
+                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref,
+                        nextLinkText);
             }
             if (StringUtils.hasText(lastLinkText)) {
                 // write last link
-                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref, lastLinkText);
+                writeListItemAndAnchor(disabledClass, tagWriter, disabledHref,
+                        lastLinkText);
             }
         } else {
             if (StringUtils.hasText(nextLinkText)) {
                 // write next link
-                writeListItemAndAnchor(innerElementClass, tagWriter, info.getNextUrl(), nextLinkText);
+                writeListItemAndAnchor(innerElementClass, tagWriter, info
+                        .getNextUrl(), nextLinkText);
             }
             if (StringUtils.hasText(lastLinkText)) {
                 // write last link
-                writeListItemAndAnchor(innerElementClass, tagWriter, info.getLastUrl(), lastLinkText);
+                writeListItemAndAnchor(innerElementClass, tagWriter, info
+                        .getLastUrl(), lastLinkText);
             }
         }
     }
@@ -540,8 +548,8 @@ public class PaginationTag extends RequestContextAwareTag {
      * @param linkText text of anchor
      * @throws JspException If fail a tag writing
      */
-    private void writeListItemAndAnchor(String classValue, TagWriter tagWriter, String href,
-            String linkText) throws JspException {
+    private void writeListItemAndAnchor(String classValue, TagWriter tagWriter,
+            String href, String linkText) throws JspException {
         tagWriter.startTag(innerElement); // <li>
         if (StringUtils.hasText(classValue)) {
             tagWriter.writeAttribute(PaginationInfo.CLASS_ATTR, classValue);

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Package containing classes related to pagination functionality.
- *
  */
 package org.terasoluna.gfw.web.pagination;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
@@ -14,9 +14,8 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Package related to Transaction Token functionality. <br> 
- * Transaction Token functionality provides flow management and <br> 
- * prevention of double submit. 
- *
+ * Package related to Transaction Token functionality. <br>
+ * Transaction Token functionality provides flow management and <br>
+ * prevention of double submit.
  */
 package org.terasoluna.gfw.web.token.transaction;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/message/MessagesPanelTagTest.java
@@ -418,7 +418,8 @@ public class MessagesPanelTagTest {
     }
 
     /**
-     * Set default messages attribute name & Use ResultMessages & change PanelElement,OuterElement and InnerElement is empty.<br>
+     * Set default messages attribute name & Use ResultMessages & change PanelElement,OuterElement and InnerElement is
+     * empty.<br>
      * check JspTagException.
      */
     @Test(expected = JspTagException.class)

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/CodeListInterceptor.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/CodeListInterceptor.java
@@ -39,7 +39,8 @@ import org.terasoluna.gfw.common.codelist.CodeList;
 /**
  * Interceptor class for setting codelist in attribute of {@link HttpServletRequest}
  * <p>
- * Default behavior is to set all the implementation beans of {@code CodeList} in the attribute of {@link HttpServletRequest}<br>
+ * Default behavior is to set all the implementation beans of {@code CodeList} in the attribute of
+ * {@link HttpServletRequest}<br>
  * In order to narrow down the target beans, pass the pattern (regular expression) corresponding to codelist ID of target beans
  * <br>
  * to {@link #setCodeListIdPattern(Pattern)} method.
@@ -78,7 +79,8 @@ public class CodeListInterceptor implements HandlerInterceptor,
      * <p>
      * Sets codelist to the attribute of {@link HttpServletRequest} after the execution of Controller.
      * </p>
-     * @see org.springframework.web.servlet.handler.HandlerInterceptorAdapter#postHandle(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, java.lang.Object, org.springframework.web.servlet.ModelAndView)
+     * @see org.springframework.web.servlet.handler.HandlerInterceptorAdapter#postHandle(javax.servlet.http.HttpServletRequest,
+     *      javax.servlet.http.HttpServletResponse, java.lang.Object, org.springframework.web.servlet.ModelAndView)
      * @since 5.4.2
      */
     @Override

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/codelist/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Package that contains classes and interface that provide CodeList functionality
- *
  */
 package org.terasoluna.gfw.web.codelist;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java
@@ -56,7 +56,8 @@ import org.springframework.web.servlet.view.AbstractView;
  * <h3>Example of bean definition file</h3>
  * 
  * <pre>
- * &lt;bean id=<strong style=color:red>&quot;sampleFileDownloadView&quot;</strong> class=&quot;org.terasoluna.gfw.web.sample.SampleFileDownloadView&quot;&gt;
+ * &lt;bean id=<strong style=
+color:red>&quot;sampleFileDownloadView&quot;</strong> class=&quot;org.terasoluna.gfw.web.sample.SampleFileDownloadView&quot;&gt;
  *     &lt;!-- injections.. --&gt;
  * &lt;/bean&gt;
  * </pre>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/AbstractFileDownloadView.java
@@ -56,8 +56,8 @@ import org.springframework.web.servlet.view.AbstractView;
  * <h3>Example of bean definition file</h3>
  * 
  * <pre>
- * &lt;bean id=<strong style=
-color:red>&quot;sampleFileDownloadView&quot;</strong> class=&quot;org.terasoluna.gfw.web.sample.SampleFileDownloadView&quot;&gt;
+ * &lt;bean id=<strong style=color:red>&quot;sampleFileDownloadView&quot;</strong>
+ *     class=&quot;org.terasoluna.gfw.web.sample.SampleFileDownloadView&quot;&gt;
  *     &lt;!-- injections.. --&gt;
  * &lt;/bean&gt;
  * </pre>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/download/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Contains classes that provide the functionality to use file download in View.
- *
  */
 package org.terasoluna.gfw.web.download;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/Functions.java
@@ -34,7 +34,8 @@ import org.terasoluna.gfw.web.util.HtmlEscapeUtils;
  * <ul>
  * <li>Escaping HTML tag using {@code f:h}</li>
  * <li>Encoding URL using {@code f:u}</li>
- * <li>Replacing new line characters with {@code <br />} using {@code f:br}</li>
+ * <li>Replacing new line characters with {@code <br />
+ * } using {@code f:br}</li>
  * <li>Output only the specified characters {@code f:cut}</li>
  * <li>Output the link text in {@code <a>} tag using {@code f:link}</li>
  * <li>Build query string from the parameters using {@code f:query}</li>
@@ -352,9 +353,8 @@ public final class Functions {
     }
 
     /**
-     * Percent-encode the "+" character in query string.
-     * This method is created for backward compatibility with spring 4.x or earlier version.
-     *
+     * Percent-encode the "+" character in query string. This method is created for backward compatibility with spring 4.x or
+     * earlier version.
      * @param query query string
      * @return encoded query string
      */

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/el/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * servlet.jsp.el package.
- *
  */
 package org.terasoluna.gfw.web.el;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilter.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/ExceptionLoggingFilter.java
@@ -52,7 +52,6 @@ import org.terasoluna.gfw.common.exception.ExceptionLogger;
  * class=&quot;org.terasoluna.gfw.web.exception.ExceptionLoggingFilter&quot;&gt;
  *   &lt;property name=&quot;exceptionLogger&quot; ref=&quot;exceptionLogger&quot; /&gt;
  * &lt;/bean&gt;
- * 
  * </pre>
  * 
  * <strong>[web.xml]</strong><br>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/SystemExceptionResolver.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/SystemExceptionResolver.java
@@ -85,7 +85,7 @@ public class SystemExceptionResolver extends SimpleMappingExceptionResolver {
      * <p>
      * Calling this method overwrites the default value {@code "resultMessages"}. <br>
      * If {@code null} or blank or space is set, then {@code ResultMessages} will not be set in request scope and
-     * {@code FlashMap}　when　{@link #setResultMessages(Exception, HttpServletRequest)} is called.
+     * {@code FlashMap} when {@link #setResultMessages(Exception, HttpServletRequest)} is called.
      * </p>
      * @param resultMessagesAttribute Attribute name used for storing result message in request scope and {@code FlashMap}.
      */
@@ -96,7 +96,7 @@ public class SystemExceptionResolver extends SimpleMappingExceptionResolver {
     /**
      * Sets the object for resolving exception code.
      * <p>
-     * If not set, exception code will not be set in request scope and response header　when
+     * If not set, exception code will not be set in request scope and response header when
      * {@link #setExceptionCode(Exception, HttpServletRequest, HttpServletResponse)} is called.
      * </p>
      * @param exceptionCodeResolver Exception code resolution object.

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * exception package.
- *
  */
 package org.terasoluna.gfw.web.exception;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/mdc/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Package for classes that provide logging functionality using MDC<br>
- * 
  */
 package org.terasoluna.gfw.web.logging.mdc;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/logging/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Package for classes that provide logging functionality<br>
- *
  */
 package org.terasoluna.gfw.web.logging;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/package-info.java
@@ -14,7 +14,6 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Contains classes that provide functionalities related to MVC.
- * For Ex. Request data processing of incoming request data
+ * Contains classes that provide functionalities related to MVC. For Ex. Request data processing of incoming request data
  */
 package org.terasoluna.gfw.web.mvc;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/mvc/support/package-info.java
@@ -14,7 +14,7 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Contains classes that provide functionality to process the Request data <br> 
+ * Contains classes that provide functionality to process the Request data <br>
  * of the incoming HTTP request
  */
 package org.terasoluna.gfw.web.mvc.support;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/pagination/package-info.java
@@ -15,6 +15,5 @@
  */
 /**
  * Package containing classes related to pagination functionality.
- *
  */
 package org.terasoluna.gfw.web.pagination;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/package-info.java
@@ -15,7 +15,6 @@
  */
 /**
  * Package related to processing of Tokens <br>
- * For Ex. Token generation 
- *
+ * For Ex. Token generation
  */
 package org.terasoluna.gfw.web.token;

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStore.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/HttpSessionTransactionTokenStore.java
@@ -137,7 +137,8 @@ public class HttpSessionTransactionTokenStore implements TransactionTokenStore {
     }
 
     /**
-     * Fetches the value stored in session corresponding to the {@link TransactionToken} received as argument to this method. <br>
+     * Fetches the value stored in session corresponding to the {@link TransactionToken} received as argument to this method.
+     * <br>
      * <p>
      * This value corresponding to the same transactionToken instance can be fetched only once. Once the value is fetched, its
      * value is cleared from the session. For all further invocations to this method for the same transactionToken instance,

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenType.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/TransactionTokenType.java
@@ -47,7 +47,8 @@ public enum TransactionTokenType {
     /**
      * Indicate that the corresponding handler method is within the transaction boundary <br>
      * <p>
-     * Transaction token check will be performed in this type of {@link TransactionToken}, but Transaction token is no update.<br>
+     * Transaction token check will be performed in this type of {@link TransactionToken}, but Transaction token is no
+     * update.<br>
      * To use if you want to take over the same transaction token between the same transaction.<br>
      * For example,This type is used in the method that does not return a transaction token, such as a file download.
      */

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/token/transaction/package-info.java
@@ -14,9 +14,8 @@
  * governing permissions and limitations under the License.
  */
 /**
- * Package related to Transaction Token functionality. <br> 
- * Transaction Token functionality provides flow management and <br> 
- * prevention of double submit. 
- *
+ * Package related to Transaction Token functionality. <br>
+ * Transaction Token functionality provides flow management and <br>
+ * prevention of double submit.
  */
 package org.terasoluna.gfw.web.token.transaction;


### PR DESCRIPTION
Please review #1084

I ran `mvn fomratter:format` to format it. As for the format result, nothing was extremely difficult to see, so no particular corrections have been made. If something is hard to see, modify formatter.xml to set a new rule or use the `formatter:off/on` tag to exclude it from formatting.
In addition to the format, the following changes are included.

- After importing the unmodified formatter.xml (version 12) into STS4.10.0 (eclipse4.19), I exported it to generate a new formatter.xml (version 21).
- Sorted the above formatter.xml for easy viewing. It also sorts the formatters used by default in formatter-maven-plugin.
- Changed to use `formatter:off/on` tag instead of listing files that are not formatted in the plugin settings of pom.xml. Along with that, I changed `formatter.use_on_off_tags` in formatter.xml to true so that the `formatter:off/on` tag can be used by default.