### PR TITLE
fix license-maven-plugin setteing #1089

### DIFF
--- a/terasoluna-gfw-common-libraries/pom.xml
+++ b/terasoluna-gfw-common-libraries/pom.xml
@@ -77,15 +77,19 @@
           <artifactId>license-maven-plugin</artifactId>
           <version>${com.mycila.license-maven-plugin.version}</version>
           <configuration>
-            <header>${project.root.basedir}/../license/header.txt</header>
-            <includes>
-              <include>src/main/java/**/*.java</include>
-              <include>src/test/java/**/*.java</include>
-            </includes>
+            <licenseSets>
+              <licenseSet>
+                <header>${project.root.basedir}/../license/header.txt</header>
+                <includes>
+                  <include>src/main/java/**/*.java</include>
+                  <include>src/test/java/**/*.java</include>
+                </includes>
+                <headerDefinitions>
+                  <headerDefinition>${project.root.basedir}/../license/header-definition.xml</headerDefinition>
+                </headerDefinitions>
+              </licenseSet>
+            </licenseSets>
             <encoding>${encoding}</encoding>
-            <headerDefinitions>
-              <headerDefinition>${project.root.basedir}/../license/header-definition.xml</headerDefinition>
-            </headerDefinitions>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Please review #1089

See:https://github.com/terasolunaorg/terasoluna-gfw/issues/1089#issuecomment-906922456

`<encoding>` is described in `<configuration>`, not in `<licenseSet>`.
I executed `mvn license:check` and confirmed the operation.