### PR TITLE
deprecated joda time

### DIFF
--- a/terasoluna-gfw-dependencies/terasoluna-gfw-jodatime-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/terasoluna-gfw-jodatime-dependencies/pom.xml
@@ -30,11 +30,6 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time-jsptags</artifactId>
-      <!-- this dependency does not pull servlet-api -->
-    </dependency>
     <!-- == End Joda-Time == -->
     <!-- == Begin Jackson == -->
     <dependency>

--- a/terasoluna-gfw-dependencies/terasoluna-gfw-jpa-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/terasoluna-gfw-jpa-dependencies/pom.xml
@@ -32,19 +32,6 @@
       <artifactId>jakarta.activation-api</artifactId>
     </dependency>
     <!-- == End Hibernate == -->
-
-    <!-- == Begin Joda-Time == -->
-    <dependency>
-      <groupId>org.jadira.usertype</groupId>
-      <artifactId>usertype.core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hibernate</groupId>
-          <artifactId>hibernate-entitymanager</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- == End Joda-Time == -->
     <!-- == End JPA == -->
   </dependencies>
 </project>

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -522,7 +522,7 @@
     <!-- == Date and Time API == -->
     <net.sargue.java-time-jsptags.version>2.0.0</net.sargue.java-time-jsptags.version>
     <!-- == Joda-Time == -->
-    <joda-time.joda-time.version>2.10.9</joda-time.joda-time.version>
+    <joda-time.joda-time.version>2.12.2</joda-time.joda-time.version>
     <joda-time.joda-time-jsptags.version>1.1.1</joda-time.joda-time-jsptags.version>
     <jadira-usertype-core.version>6.0.1.GA</jadira-usertype-core.version>
     <!-- == Google == -->

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -368,16 +368,6 @@
         <artifactId>joda-time</artifactId>
         <version>${joda-time.joda-time.version}</version>
       </dependency>
-      <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time-jsptags</artifactId>
-        <version>${joda-time.joda-time-jsptags.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jadira.usertype</groupId>
-        <artifactId>usertype.core</artifactId>
-        <version>${jadira-usertype-core.version}</version>
-      </dependency>
       <!-- == End Joda-Time == -->
 
       <!-- == Begin Google == -->
@@ -523,8 +513,6 @@
     <net.sargue.java-time-jsptags.version>2.0.0</net.sargue.java-time-jsptags.version>
     <!-- == Joda-Time == -->
     <joda-time.joda-time.version>2.12.2</joda-time.joda-time.version>
-    <joda-time.joda-time-jsptags.version>1.1.1</joda-time.joda-time-jsptags.version>
-    <jadira-usertype-core.version>6.0.1.GA</jadira-usertype-core.version>
     <!-- == Google == -->
     <guava.version>31.1-jre</guava.version>
     <!-- == Apache Commons == -->


### PR DESCRIPTION
Please review #1187.

The following are fixed

* Joda-Time version up
* Removed libraries (JSP Tag Library, Jadira Usertype) from dependencies that no longer work with the base version of Jakarta
* Joda-Time Factory provided by terasoluna-gfw has been deprecated
