### PR TITLE
fixed deprecated methods #1222

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DateConvertUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/date/DateConvertUtilsTest.java
@@ -33,7 +33,7 @@ public class DateConvertUtilsTest {
         // set up
         Constructor<DateConvertUtils> constructor = DateConvertUtils.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageTest.java
@@ -85,6 +85,11 @@ public class ResultMessageTest {
         ResultMessage.fromText(null);
     }
 
+    /**
+     * This test uses SerializationUtils#deserialize(byte[]) Although this mechanism is deprecated, it is still used because the
+     * data to be deserialized is guaranteed.
+     */
+    @SuppressWarnings("deprecation")
     @Test(expected = None.class)
     public void test10() {
         byte[] serialized = SerializationUtils.serialize(ResultMessage.fromText(

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessageUtilsTest.java
@@ -42,7 +42,7 @@ public class ResultMessageUtilsTest {
         // set up
         Constructor<ResultMessageUtils> constructor = ResultMessageUtils.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessagesTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/message/ResultMessagesTest.java
@@ -294,6 +294,11 @@ public class ResultMessagesTest {
         assertThat(messages.getList(), contains(msg1, msg2));
     }
 
+    /**
+     * This test uses SerializationUtils#deserialize(byte[]) Although this mechanism is deprecated, it is still used because the
+     * data to be deserialized is guaranteed.
+     */
+    @SuppressWarnings("deprecation")
     @Test(expected = None.class)
     public void testSerialization() {
         byte[] serialized = SerializationUtils.serialize(

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/query/QueryEscapeUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/query/QueryEscapeUtilsTest.java
@@ -190,7 +190,7 @@ public class QueryEscapeUtilsTest {
         // set up
         Constructor<QueryEscapeUtils> constructor = QueryEscapeUtils.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/AbstractJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/AbstractJodaTimeDateFactoryTest.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class AbstractJodaTimeDateFactoryTest {
 
     @Test
@@ -84,6 +85,7 @@ public class AbstractJodaTimeDateFactoryTest {
     }
 }
 
+@SuppressWarnings("deprecation")
 class StubDateFactory extends AbstractJodaTimeDateFactory {
     @Override
     public DateTime newDateTime() {

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/DefaultJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/DefaultJodaTimeDateFactoryTest.java
@@ -22,6 +22,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class DefaultJodaTimeDateFactoryTest {
 
     @Test

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcAdjustedJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcAdjustedJodaTimeDateFactoryTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+@SuppressWarnings("deprecation")
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 @Transactional

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcFixedJodaTimeDateFactoryTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-jodatime/src/test/java/org/terasoluna/gfw/common/date/jodatime/JdbcFixedJodaTimeDateFactoryTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+@SuppressWarnings("deprecation")
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 @Transactional

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalfTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/test/java/org/terasoluna/gfw/common/fullhalf/DefaultFullHalfTest.java
@@ -30,7 +30,7 @@ public class DefaultFullHalfTest {
         // set up
         Constructor<DefaultFullHalf> constructor = DefaultFullHalf.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraintvalidators/ConstraintValidatorsUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-validator/src/test/java/org/terasoluna/gfw/common/validator/constraintvalidators/ConstraintValidatorsUtilsTest.java
@@ -31,7 +31,7 @@ public class ConstraintValidatorsUtilsTest {
         // set up
         Constructor<ConstraintValidatorsUtils> constructor = ConstraintValidatorsUtils.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/pagination/PaginationTagTest.java
@@ -989,6 +989,11 @@ public class PaginationTagTest {
         tag1.setEnableLinkOfCurrentPage("");
     }
 
+    /**
+     * This test uses SerializationUtils#deserialize(byte[]) Although this mechanism is deprecated, it is still used because the
+     * data to be deserialized is guaranteed.
+     */
+    @SuppressWarnings("deprecation")
     @Test(expected = None.class)
     public void testSerialization() {
         byte[] serialized = SerializationUtils.serialize(new PaginationTag());

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/util/JspTagUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/src/test/java/org/terasoluna/gfw/web/util/JspTagUtilsTest.java
@@ -34,7 +34,7 @@ public class JspTagUtilsTest {
         // set up
         Constructor<JspTagUtils> constructor = JspTagUtils.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/el/FunctionsTest.java
@@ -43,7 +43,7 @@ public class FunctionsTest {
         // set up
         Constructor<Functions> constructor = Functions.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/HtmlEscapeUtilsTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/java/org/terasoluna/gfw/web/util/HtmlEscapeUtilsTest.java
@@ -30,7 +30,7 @@ public class HtmlEscapeUtilsTest {
         // set up
         Constructor<HtmlEscapeUtils> constructor = HtmlEscapeUtils.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible(), is(false));
+        assertThat(constructor.canAccess(null), is(false));
         constructor.setAccessible(true);
 
         // assert


### PR DESCRIPTION
Please review #1222 

`SerializationUtils.deserialize()` is deprecated because it can cause RCE vulnerabilities.

However, the class used is a
- test class to see if classes implementing Serializable can be serialized and deserialized without exception.
- The target of deserialization is the test data prepared in the immediately preceding process, and we do not do anything to obtain the data from outside.

In addition, `SerializationUtils.deserialize()` is used as it is because no valid general library could be found.


