### PR TITLE
update the plugin version #1362

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,10 @@
     </scm>
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <org.jacoco.jacoco-maven-plugin.version>0.8.8</org.jacoco.jacoco-maven-plugin.version>
-        <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+        <org.jacoco.jacoco-maven-plugin.version>0.8.12</org.jacoco.jacoco-maven-plugin.version>
         <org.eluder.coveralls.coveralls-maven-plugin.version>4.3.0</org.eluder.coveralls.coveralls-maven-plugin.version>
-        <org.apache.maven.plugins.maven-gpg-plugin.version>3.0.1</org.apache.maven.plugins.maven-gpg-plugin.version>
-        <org.sonatype.plugins.nexus-staging-maven-plugin.version>1.6.13</org.sonatype.plugins.nexus-staging-maven-plugin.version>
+        <org.apache.maven.plugins.maven-gpg-plugin.version>3.2.7</org.apache.maven.plugins.maven-gpg-plugin.version>
+        <org.sonatype.plugins.nexus-staging-maven-plugin.version>1.7.0</org.sonatype.plugins.nexus-staging-maven-plugin.version>
         <!-- == Project Properties == -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -163,35 +162,6 @@
                                     <sourceDirectory>terasoluna-gfw-common-libraries/terasoluna-gfw-codepoints/src/main/java</sourceDirectory>
                                     <sourceDirectory>terasoluna-gfw-common-libraries/terasoluna-gfw-string/src/main/java</sourceDirectory>
                                 </sourceDirectories>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>xml-check-format</id>
-            <modules>
-                <module>terasoluna-gfw-common-libraries</module>
-                <module>terasoluna-gfw-dependencies</module>
-            </modules>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.codehaus.mojo</groupId>
-                            <artifactId>xml-maven-plugin</artifactId>
-                            <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
-                            <configuration>
-                                <indentSize>2</indentSize>
-                                <formatFileSets>
-                                    <formatFileSet>
-                                        <directory>${project.basedir}/terasoluna-gfw-parent</directory>
-                                        <includes>
-                                            <include>**/*.xml</include>
-                                        </includes>
-                                    </formatFileSet>
-                                </formatFileSets>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/terasoluna-gfw-common-libraries/pom.xml
+++ b/terasoluna-gfw-common-libraries/pom.xml
@@ -78,14 +78,6 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>xml-maven-plugin</artifactId>
-                    <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
-                    <configuration>
-                        <indentSize>2</indentSize>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.eluder.coveralls</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
                     <version>${org.eluder.coveralls.coveralls-maven-plugin.version}</version>
@@ -117,9 +109,8 @@
     </build>
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <org.apache.maven.plugins.maven-surefire-plugin.version>3.0.0-M7</org.apache.maven.plugins.maven-surefire-plugin.version>
-        <org.jacoco.jacoco-maven-plugin.version>0.8.11</org.jacoco.jacoco-maven-plugin.version>
-        <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
+        <org.apache.maven.plugins.maven-surefire-plugin.version>3.5.2</org.apache.maven.plugins.maven-surefire-plugin.version>
+        <org.jacoco.jacoco-maven-plugin.version>0.8.12</org.jacoco.jacoco-maven-plugin.version>
         <org.eluder.coveralls.coveralls-maven-plugin.version>4.3.0</org.eluder.coveralls.coveralls-maven-plugin.version>
         <!-- == Project Properties == -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web-jsp/pom.xml
@@ -55,20 +55,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>xml-maven-plugin</artifactId>
-                <configuration>
-                    <formatFileSets>
-                        <formatFileSet>
-                            <directory>${project.basedir}</directory>
-                            <includes>
-                                <include>src/**/*.tld</include>
-                            </includes>
-                        </formatFileSet>
-                    </formatFileSets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/terasoluna-gfw-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/pom.xml
@@ -41,22 +41,4 @@
         <module>terasoluna-gfw-recommended-dependencies</module>
         <module>terasoluna-gfw-recommended-web-dependencies</module>
     </modules>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>xml-maven-plugin</artifactId>
-                    <version>${org.codehaus.mojo.xml-maven-plugin.version}</version>
-                    <configuration>
-                        <indentSize>2</indentSize>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-    <properties>
-        <!-- == Maven Plugin Versions == -->
-        <org.codehaus.mojo.xml-maven-plugin.version>1.0.2</org.codehaus.mojo.xml-maven-plugin.version>
-    </properties>
 </project>

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -70,7 +70,7 @@
                             <id>install</id>
                             <phase>install</phase>
                             <goals>
-                                <goal>sources</goal>
+                                <goal>resolve-sources</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -465,21 +465,21 @@
     </dependencyManagement>
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <org.apache.maven.plugins.maven-project-info-reports-plugin.version>3.4.1</org.apache.maven.plugins.maven-project-info-reports-plugin.version>
-        <org.apache.maven.plugins.maven-compiler-plugin.version>3.10.1</org.apache.maven.plugins.maven-compiler-plugin.version>
-        <org.apache.maven.plugins.maven-dependency-plugin.version>3.3.0</org.apache.maven.plugins.maven-dependency-plugin.version>
-        <org.apache.maven.plugins.maven-resources-plugin.version>3.3.0</org.apache.maven.plugins.maven-resources-plugin.version>
-        <org.apache.maven.plugins.maven-source-plugin.version>3.2.1</org.apache.maven.plugins.maven-source-plugin.version>
-        <org.apache.maven.plugins.maven-javadoc-plugin.version>3.4.1</org.apache.maven.plugins.maven-javadoc-plugin.version>
-        <org.apache.maven.plugins.maven-jar-plugin.version>3.2.2</org.apache.maven.plugins.maven-jar-plugin.version>
-        <org.apache.maven.plugins.maven-assembly-plugin.version>3.4.2</org.apache.maven.plugins.maven-assembly-plugin.version>
-        <org.apache.maven.plugins.maven-clean-plugin.version>3.2.0</org.apache.maven.plugins.maven-clean-plugin.version>
-        <org.apache.maven.plugins.maven-install-plugin.version>3.0.1</org.apache.maven.plugins.maven-install-plugin.version>
-        <org.apache.maven.plugins.maven-deploy-plugin.version>3.0.0</org.apache.maven.plugins.maven-deploy-plugin.version>
-        <org.apache.maven.plugins.maven-site-plugin.version>4.0.0-M3</org.apache.maven.plugins.maven-site-plugin.version>
-        <org.codehaus.cargo.cargo-maven3-plugin.version>1.10.11</org.codehaus.cargo.cargo-maven3-plugin.version>
-        <org.apache.maven.plugins.maven-gpg-plugin.version>3.0.1</org.apache.maven.plugins.maven-gpg-plugin.version>
-        <org.sonatype.plugins.nexus-staging-maven-plugin.version>1.6.13</org.sonatype.plugins.nexus-staging-maven-plugin.version>
+        <org.apache.maven.plugins.maven-project-info-reports-plugin.version>3.8.0</org.apache.maven.plugins.maven-project-info-reports-plugin.version>
+        <org.apache.maven.plugins.maven-compiler-plugin.version>3.13.0</org.apache.maven.plugins.maven-compiler-plugin.version>
+        <org.apache.maven.plugins.maven-dependency-plugin.version>3.8.1</org.apache.maven.plugins.maven-dependency-plugin.version>
+        <org.apache.maven.plugins.maven-resources-plugin.version>3.3.1</org.apache.maven.plugins.maven-resources-plugin.version>
+        <org.apache.maven.plugins.maven-source-plugin.version>3.3.1</org.apache.maven.plugins.maven-source-plugin.version>
+        <org.apache.maven.plugins.maven-javadoc-plugin.version>3.11.2</org.apache.maven.plugins.maven-javadoc-plugin.version>
+        <org.apache.maven.plugins.maven-jar-plugin.version>3.4.2</org.apache.maven.plugins.maven-jar-plugin.version>
+        <org.apache.maven.plugins.maven-assembly-plugin.version>3.7.1</org.apache.maven.plugins.maven-assembly-plugin.version>
+        <org.apache.maven.plugins.maven-clean-plugin.version>3.4.0</org.apache.maven.plugins.maven-clean-plugin.version>
+        <org.apache.maven.plugins.maven-install-plugin.version>3.1.3</org.apache.maven.plugins.maven-install-plugin.version>
+        <org.apache.maven.plugins.maven-deploy-plugin.version>3.1.3</org.apache.maven.plugins.maven-deploy-plugin.version>
+        <org.apache.maven.plugins.maven-site-plugin.version>4.0.0-M16</org.apache.maven.plugins.maven-site-plugin.version>
+        <org.codehaus.cargo.cargo-maven3-plugin.version>1.10.15</org.codehaus.cargo.cargo-maven3-plugin.version>
+        <org.apache.maven.plugins.maven-gpg-plugin.version>3.2.7</org.apache.maven.plugins.maven-gpg-plugin.version>
+        <org.sonatype.plugins.nexus-staging-maven-plugin.version>1.7.0</org.sonatype.plugins.nexus-staging-maven-plugin.version>
         <!-- == Dependency Versions == -->
         <!-- == TERASOLUNA == -->
         <terasoluna.gfw.version>5.10.0-SNAPSHOT</terasoluna.gfw.version>


### PR DESCRIPTION
Please review #1362 
- Removed xml-maven-plugin for formatting XML files in VSCode.
- The goal of maven-dependency-plugin, `sources`, has been deprecated and corrected to the appropriate value.
  https://maven.apache.org/plugins/maven-dependency-plugin/plugin-info.html
