### PR TITLE
[5.10.x] Modify the processing to take into account the case where queryForObject() returns null.

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/time/JdbcClockFactory.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/main/java/org/terasoluna/gfw/common/time/JdbcClockFactory.java
@@ -15,13 +15,12 @@
  */
 package org.terasoluna.gfw.common.time;
 
+import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-
 import javax.sql.DataSource;
-
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
@@ -69,8 +68,11 @@ public class JdbcClockFactory implements ClockFactory {
      * @return instant of date and time
      */
     private Instant instant(ZoneId zone) {
-        return jdbcTemplate.queryForObject(currentTimestampQuery, //
-                (rs, rowNum) -> rs.getTimestamp(1).toLocalDateTime().atZone(zone)) //
-                .toInstant();
+        Timestamp timestamp = jdbcTemplate.queryForObject(currentTimestampQuery,
+                (rs, rowNum) -> rs.getTimestamp(1));
+        if (timestamp == null) {
+            throw new IllegalStateException("Failed to retrieve current timestamp from database");
+        }
+        return timestamp.toLocalDateTime().atZone(zone).toInstant();
     }
 }

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/time/JdbcClockFactoryTest.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/java/org/terasoluna/gfw/common/time/JdbcClockFactoryTest.java
@@ -18,16 +18,14 @@ package org.terasoluna.gfw.common.time;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-
+import static org.junit.Assert.assertThrows;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
-
 import javax.sql.DataSource;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -145,5 +143,14 @@ public class JdbcClockFactoryTest {
 
         ZonedDateTime now2 = ZonedDateTime.now(clock);
         assertThat(now2.isAfter(now), is(true));
+    }
+
+    @Test
+    public void testInstantNull() throws Exception {
+        clockFactory = new JdbcClockFactory(dataSource, "SELECT null FROM system_date");
+        IllegalStateException e = assertThrows(IllegalStateException.class, () -> {
+            clockFactory.fixed();
+        });
+        assertThat(e.getMessage(), is("Failed to retrieve current timestamp from database"));
     }
 }


### PR DESCRIPTION
Modify the processing to take into account the case where queryForObject() returns null. #1396

(cherry picked from commit 44c79bc816dec2084576c413ef6e4867391bfb23)

Please review #1401.
