### PR TITLE
Apply Spring Boot 4.0.0-M1

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/pom.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/pom.xml
@@ -76,6 +76,11 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <!-- JCL -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
         <!-- == End Logging == -->
 
         <!-- == Begin Spring == -->

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/SystemExceptionResolver.java
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/main/java/org/terasoluna/gfw/web/exception/SystemExceptionResolver.java
@@ -15,7 +15,7 @@
  */
 package org.terasoluna.gfw.web.exception;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.FlashMap;
 import org.springframework.web.servlet.ModelAndView;

--- a/terasoluna-gfw-parent/pom.xml
+++ b/terasoluna-gfw-parent/pom.xml
@@ -348,9 +348,9 @@
         <!-- == Cargo Plugin == -->
         <cargo.jvmargs>-Xms512m -Xmx1024m</cargo.jvmargs>
         <cargo.daemon.url>http://localhost:18000</cargo.daemon.url>
-        <cargo.container.id>tomcat10x</cargo.container.id>
-        <cargo.container.url>https://archive.apache.org/dist/tomcat/tomcat-10/v${cargo.tomcat10.version}/bin/apache-tomcat-${cargo.tomcat10.version}.zip</cargo.container.url>
-        <cargo.tomcat10.version>10.1.34</cargo.tomcat10.version>
+        <cargo.container.id>tomcat11x</cargo.container.id>
+        <cargo.container.url>https://archive.apache.org/dist/tomcat/tomcat-11/v${cargo.tomcat11.version}/bin/apache-tomcat-${cargo.tomcat11.version}.zip</cargo.container.url>
+        <cargo.tomcat11.version>11.0.9</cargo.tomcat11.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
Please review #1412.

JCL 1.3 may cause errors in OSS because it is a non-serializable class. Therefore, jcl-over-slf4j is included.
This response is subject to change at a later date.

relates to [TSF4J5-6880](https://terasolunaorg.atlassian.net/browse/TSF4J5-6880).