### PR TITLE
jackson2 to jackson3. #1423

### DIFF
--- a/terasoluna-gfw-dependencies/terasoluna-gfw-common-dependencies/pom.xml
+++ b/terasoluna-gfw-dependencies/terasoluna-gfw-common-dependencies/pom.xml
@@ -26,9 +26,19 @@
         </dependency>
         <!-- == End TERASOLUNA == -->
         <!-- == Begin Jackson == -->
+        <!-- jackson 3.x -->
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <!-- jackson 2.x -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
         <!-- == End Jackson == -->
 


### PR DESCRIPTION
Please review #1423.

relates to [TSF4J5-7195](https://terasolunaorg.atlassian.net/browse/TSF4J5-7195).

When attempting to use Jackson3 with XMLConfig, it cannot be handled through normal methods, so Jackson2 is retained for XMLConfig.

