### PR TITLE
[5.10.x] Vulnerability that may result in logs being output that exploit terminal (console) functionality #1434

### DIFF
--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/resources/logback.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-common/src/test/resources/logback.xml
@@ -3,8 +3,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <Target>System.out</Target>
         <encoder>
-            <pattern><![CDATA[%d{HH:mm:ss} [%thread] [%-5level] [%-48logger{48}] - %replace(%msg){'(\r\n|\r|\n)','$1  '}%n%replace(%replace(%xEx){'(\r\n|\r|\n)','$1  '}){'  $',''}%nopex]]>
-        </pattern>
+            <pattern><![CDATA[%d{HH:mm:ss} [%thread] [%-5level] [%-48logger{48}] - %replace(%replace(%msg){'[\p{IsControl}&&[^\t\r\n]]','<CTRL>'}){'(\r\n|\r|\n)','$1  '}%n%replace(%replace(%replace(%xEx){'[\p{IsControl}&&[^\t\r\n]]','<CTRL>'}){'(\r\n|\r|\n)','$1  '}){'  $',''}%nopex]]></pattern>
         </encoder>
     </appender>
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-security-web/src/test/resources/logback.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-security-web/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration DEBUG="false">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern><![CDATA[date:%d{yyyy-MM-dd HH:mm:ss}\tthread:%thread\tlevel:%-5level\tlogger:%-48logger{48}\tmessage:%replace(%msg){'(\r\n|\r|\n)','$1  '}%n%replace(%replace(%xEx){'(\r\n|\r|\n)','$1  '}){'  $',''}%nopex]]></pattern>
+            <pattern><![CDATA[date:%d{yyyy-MM-dd HH:mm:ss}\tthread:%thread\tlevel:%-5level\tlogger:%-48logger{48}\tmessage:%replace(%replace(%msg){'[\p{IsControl}&&[^\t\r\n]]','<CTRL>'}){'(\r\n|\r|\n)','$1  '}%n%replace(%replace(%replace(%xEx){'[\p{IsControl}&&[^\t\r\n]]','<CTRL>'}){'(\r\n|\r|\n)','$1  '}){'  $',''}%nopex]]></pattern>
         </encoder>
     </appender>
 

--- a/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/resources/logback.xml
+++ b/terasoluna-gfw-common-libraries/terasoluna-gfw-web/src/test/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration DEBUG="false">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern><![CDATA[date:%d{yyyy-MM-dd HH:mm:ss}\tthread:%thread\tlevel:%-5level\tlogger:%-48logger{48}\tmessage:%replace(%msg){'(\r\n|\r|\n)','$1  '}%n%replace(%replace(%xEx){'(\r\n|\r|\n)','$1  '}){'  $',''}%nopex]]></pattern>
+            <pattern><![CDATA[date:%d{yyyy-MM-dd HH:mm:ss}\tthread:%thread\tlevel:%-5level\tlogger:%-48logger{48}\tmessage:%replace(%replace(%msg){'[\p{IsControl}&&[^\t\r\n]]','<CTRL>'}){'(\r\n|\r|\n)','$1  '}%n%replace(%replace(%replace(%xEx){'[\p{IsControl}&&[^\t\r\n]]','<CTRL>'}){'(\r\n|\r|\n)','$1  '}){'  $',''}%nopex]]></pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Vulnerability that may result in logs being output that exploit terminal (console) functionality #1434

(cherry picked from commit 4cbcd2a42204d7a12e695efe959284af42cd4fe0)

Please review #1437.
